### PR TITLE
Include actions to open the Deck Overview for a given deck name and go to the Deck Browser

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -507,6 +507,19 @@ class AnkiBridge:
         reviewer._answerCard(ease)
         return True
 
+    def guiDeckOverview(self, name):
+        collection = self.collection()
+        if collection is not None:
+            deck = collection.decks.byName(name)
+            if (deck is not None):
+                collection.decks.select(deck['id'])
+                self.window().onOverview()
+                return True
+        return False
+
+    def guiDeckBrowser(self):
+        self.window().moveToState("deckBrowser")
+        return True
 
 #
 # AnkiConnect
@@ -630,6 +643,12 @@ class AnkiConnect:
 
     def api_guiShowAnswer(self):
         return self.anki.guiShowAnswer()
+    
+    def api_guiDeckOverview(self, name):
+        return self.anki.guiDeckOverview(name)
+
+    def api_guiDeckBrowser(self):
+        return self.anki.guiDeckBrowser()
 
 
 #

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -511,7 +511,7 @@ class AnkiBridge:
         collection = self.collection()
         if collection is not None:
             deck = collection.decks.byName(name)
-            if (deck is not None):
+            if deck is not None:
                 collection.decks.select(deck['id'])
                 self.window().onOverview()
                 return True
@@ -519,7 +519,6 @@ class AnkiBridge:
 
     def guiDeckBrowser(self):
         self.window().moveToState("deckBrowser")
-        return True
 
 #
 # AnkiConnect

--- a/README.md
+++ b/README.md
@@ -390,6 +390,40 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ```
     true
     ```
+*   **guiDeckOverview**
+
+    Opens the Deck Overview screen for the deck with the given name; returns `true` if succeeded or `False` otherwise.
+
+    *Sample request*:
+    ```
+    {
+        "action": "guiDeckOverview",
+		"params": {
+			"name": "Default"
+		}
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
+    ```
+
+*   **guiDeckBrowser**
+
+    Opens the Deck Browser screen; returns `true` if succeeded or `null` otherwise.
+
+    *Sample request*:
+    ```
+    {
+        "action": "guiDeckBrowser"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
+    ```
 
 *   **upgrade**
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ```
 *   **guiDeckOverview**
 
-    Opens the Deck Overview screen for the deck with the given name; returns `true` if succeeded or `False` otherwise.
+    Opens the Deck Overview screen for the deck with the given name; returns `true` if succeeded or `false` otherwise.
 
     *Sample request*:
     ```
@@ -411,7 +411,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
 
 *   **guiDeckBrowser**
 
-    Opens the Deck Browser screen; returns `true` if succeeded or `null` otherwise.
+    Opens the Deck Browser screen.
 
     *Sample request*:
     ```
@@ -422,7 +422,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
 
     *Sample response*:
     ```
-    true
+    null
     ```
 
 *   **upgrade**


### PR DESCRIPTION
Those actions would be useful if one wants to control user review. With it, you can go to a specific deck so you can review it (with the actions included by @CharlesHenry on his fork) and you can also go back to the Deck Browser screen, so you can stop the review process.

I don't know to which extent the author wants to increase the number of actions available. I'll need to implement full automation of the review process. If the author wants to keep his codebase simple, just reject this pull request and I can work my API needs on my fork.

By the way, it would be nice if we reestructure the code so each action can reside on its own file. I think that way would be easier to maintain in the case the API grows.