### PR TITLE
Fix bug where guiDeckReview always returns null

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -737,7 +737,7 @@ class AnkiConnect:
 
     @webApi
     def guiDeckReview(self, name):
-        self.anki.guiDeckReview(name)
+        return self.anki.guiDeckReview(name)
 
 
 #

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
 
     *Sample response*:
     ```
-    null
+    true
     ```
 
 *   **upgrade**


### PR DESCRIPTION
The README says that guiDeckReview returns true or false, but the webapi function doesn't return anything and the README's sample response shows `null`.