### PR TITLE
Call startEditing before / stopEditing after tagging

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -376,7 +376,9 @@ class AnkiBridge:
 
 
     def addTags(self, notes, tags, add=True):
+        self.startEditing()
         aqt.mw.col.tags.bulkAdd(notes, tags, add)
+        self.stopEditing()
 
 
     def suspend(self, cards, suspend=True):


### PR DESCRIPTION
Didn't realize I had to do this initially - usually there's no problem, but if a card you're trying to edit is selected in the browser it can cause problems. Suspending is okay though