### PR TITLE
Fix issue #20; add isSuspended function; update code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ Below is a list of currently supported actions. Requests with invalid actions or
 
 *   **suspend**
 
-    Suspend cards by card ID.
+    Suspend cards by card ID; returns `true` if successful (at least one card wasn't already suspended) or `false`
+    otherwise.
 
     *Sample request*:
     ```
@@ -361,12 +362,13 @@ Below is a list of currently supported actions. Requests with invalid actions or
 
     *Sample response*:
     ```
-    null
+    true
     ```
 
 *   **unsuspend**
 
-    Unsuspend cards by card ID.
+    Unsuspend cards by card ID; returns `true` if successful (at least one card was previously suspended) or `false`
+    otherwise.
 
     *Sample request*:
     ```
@@ -380,7 +382,26 @@ Below is a list of currently supported actions. Requests with invalid actions or
 
     *Sample response*:
     ```
-    null
+    true
+    ```
+
+*   **isSuspended**
+
+    Returns `true` if the given card is suspended or `false` otherwise.
+
+    *Sample request*:
+    ```
+    {
+        "action": "isSuspended",
+        "params": {
+            "card": 1483959291685
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    false
     ```
 
 *   **findNotes**


### PR DESCRIPTION
I realized the problem only occurs when all the cards given are already suspended - in my webapp, I'm automatically suspending certain cards by state, and because I'm reloading frequently to test it it means that the suspend function is called again with the same cards.

This is why I didn't realize that normally it works correctly, and also why it isn't a problem in the card browser - you can only toggle the suspended state, not suspend cards which are already suspended.

I also put startEditing / stopEditing calls around the suspend calls, to make sure the deck overview numbers are updated (although these aren't needed functionally). Additionally I changed `aqt.mw.col` to `self.collection()` in the new functions I wrote to match the style of the others.