### PR TITLE
Add deckNamesToIds and deckIds actions

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -576,6 +576,14 @@ class AnkiBridge:
         self.stopEditing()
 
 
+    def deckNamesToIds(self, decks):
+        deckIds = []
+        for deck in decks:
+            id = self.collection().decks.id(deck)
+            deckIds.append(id)
+        return deckIds
+
+
     def cardsToNotes(self, cards):
         return self.collection().db.list('select distinct nid from cards where id in ' + anki.utils.ids2str(cards))
 
@@ -872,6 +880,11 @@ class AnkiConnect:
     @webApi
     def deleteDecks(self, decks, cardsToo=False):
         return self.anki.deleteDecks(decks, cardsToo)
+
+
+    @webApi
+    def deckNamesToIds(self, decks):
+        return self.anki.deckNamesToIds(decks)
 
 
     @webApi

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -515,6 +515,11 @@ class AnkiBridge:
             return collection.decks.allNames()
 
 
+    def deckIds(self):
+        deckNames = self.deckNames()
+        return self.deckNamesToIds(deckNames)
+
+
     def deckNameFromId(self, deckId):
         collection = self.collection()
         if collection is not None:
@@ -747,6 +752,11 @@ class AnkiConnect:
     @webApi
     def deckNames(self):
         return self.anki.deckNames()
+
+
+    @webApi
+    def deckIds(self):
+        return self.anki.deckIds()
 
 
     @webApi

--- a/README.md
+++ b/README.md
@@ -576,6 +576,25 @@ Below is a list of currently supported actions. Requests with invalid actions or
     null
     ```
 
+*   **deckNamesToIds**
+
+    Returns an array of deck IDs for the given deck names, in order given.
+
+    *Sample request*:
+    ```
+    {
+        "action": "deckNamesToIds",
+        "params": {
+            "decks": ["Default", "Japanese", "Chinese"]
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    [1, 1500600287679, 1500604741367]
+    ```
+
 *   **cardsToNotes**
 
     Returns an (unordered) array of note IDs for the given card IDs. For cards with the same note, the ID is only

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ```
     4
     ```
+
 *   **deckNames**
 
     Gets the complete list of deck names for the current user.
@@ -119,6 +120,22 @@ Below is a list of currently supported actions. Requests with invalid actions or
     [
         "Default"
     ]
+    ```
+
+*   **deckIds**
+
+    Gets the complete list of deck IDs for the current user, in the same order as **deckNames**.
+
+    *Sample request*:
+    ```
+    {
+        "action": "deckIDs"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    [1]
     ```
 
 *   **modelNames**


### PR DESCRIPTION
`deckNamesToIds` converts an array of names to IDs; `deckIds` returns the deck IDs in the same order as `deckNames` (useful for multi queries to get both at a time).

Maybe we should expose the internal `deckNameFromId` function as `deckIdsToNames`?