### PR TITLE
Add guiStartCardTimer function

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -640,7 +640,8 @@ class AnkiBridge:
         if card is not None:
             card.startTimer()
             return True
-
+        else:
+            return False
 
     def guiShowQuestion(self):
         if self.guiReviewActive():

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -631,6 +631,17 @@ class AnkiBridge:
             }
 
 
+    def guiStartCardTimer(self):
+        if not self.guiReviewActive():
+            return False
+
+        card = self.reviewer().card
+
+        if card is not None:
+            card.startTimer()
+            return True
+
+
     def guiShowQuestion(self):
         if self.guiReviewActive():
             self.reviewer()._showQuestion()
@@ -892,6 +903,11 @@ class AnkiConnect:
     @webApi
     def guiCurrentCard(self):
         return self.anki.guiCurrentCard()
+
+
+    @webApi
+    def guiStartCardTimer(self):
+        return self.anki.guiStartCardTimer()
 
 
     @webApi

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
         "Japanese::JLPT N3": [1502298036657, 1502298033753]
     }
     ```
-    
+
 
 *   **changeDeck**
 
@@ -554,7 +554,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ```
     null
     ```
-    
+
 *   **deleteDecks**
 
     Deletes decks with the given names. If `cardsToo` is `true` (defaults to `false` if unspecified), the cards within
@@ -670,6 +670,22 @@ Below is a list of currently supported actions. Requests with invalid actions or
         "cardId": 1498938915662,
         "buttons": [1, 2, 3]
     }
+    ```
+
+*   **guiStartCardTimer**
+
+    Starts or resets the 'timerStarted' value for the current card. This is useful for deferring the start time to when it is displayed via the API, allowing the recorded time taken to answer the card to be more accurate when calling guiAnswerCard.
+
+    *Sample request*:
+    ```
+    {
+        "action": "guiStartCardTimer"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
     ```
 
 *   **guiShowQuestion**


### PR DESCRIPTION
Starts or resets the 'timerStarted' value for the current card. This is useful for deferring the start time to when it is displayed via the API, allowing the recorded time taken to answer the card to be more accurate when calling guiAnswerCard.