### PR TITLE
Allow other add-ons to add headers

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -199,6 +199,19 @@ class AjaxServer:
         self.handler = handler
         self.clients = []
         self.sock = None
+        self.resetHeaders()
+
+
+    def addHeader(self, name, value):
+        self.headers.append([name, value])
+    
+    
+    def resetHeaders(self):
+        self.headers = [
+            ['HTTP/1.1 200 OK', None],
+            ['Content-Type', 'text/json'],
+            ['Content-Length', '']
+        ]
 
 
     def advance(self):
@@ -243,11 +256,9 @@ class AjaxServer:
                 body = json.dumps(None);
 
         resp = bytes()
-        headers = [
-            ['HTTP/1.1 200 OK', None],
-            ['Content-Type', 'text/json'],
-            ['Content-Length', str(len(body))]
-        ]
+        
+        headers = self.headers
+        headers[2][1] = str(len(body))
 
         for key, value in headers:
             if value is None:


### PR DESCRIPTION
Reason for adding: I've converted my webapp to work as an Anki addon - now it runs on an HTTP server and uses XMLHttpRequest, instead of local files and GM_xmlhttpRequest (Tampermonkey) to access AnkiConnect.

By default, CORS prevents my app (127.0.0.1:5678) from accessing AnkiConnect (127.0.0.1:8765). With the new functions, I can add the following to the start of the addon to allow access:

```python
from AnkiConnect import ac
ac.server.addHeader("Access-Control-Allow-Origin", "http://127.0.0.1:5678")
```

(See https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS for more info about CORS)