### PR TITLE
Improve handling of HTTP headers

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -202,16 +202,22 @@ class AjaxServer:
         self.resetHeaders()
 
 
-    def addHeader(self, name, value):
-        self.headers.append([name, value])
-    
-    
+    def setHeader(self, name, value):
+        self.headers[name] = value
+
+
     def resetHeaders(self):
-        self.headers = [
-            ['HTTP/1.1 200 OK', None],
-            ['Content-Type', 'text/json'],
-            ['Content-Length', '']
-        ]
+        self.headers = {
+            'HTTP/1.1 200 OK': None,
+            'Content-Type': 'text/json'
+        }
+
+
+    def getHeaders(self):
+        headers = []
+        for name in self.headers:
+            headers.append([name, self.headers[name]])
+        return headers
 
 
     def advance(self):
@@ -256,9 +262,9 @@ class AjaxServer:
                 body = json.dumps(None);
 
         resp = bytes()
-        
-        headers = self.headers
-        headers[2][1] = str(len(body))
+
+        self.setHeader('Content-Length', str(len(body)))
+        headers = self.getHeaders()
 
         for key, value in headers:
             if value is None:

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -215,9 +215,9 @@ class AjaxServer:
 
 
     def getHeaders(self):
-        headers = self.headers
+        headers = self.headers[:]
         for name in self.extraHeaders:
-            headers.append([name, self.headers[name]])
+            headers.append([name, self.extraHeaders[name]])
         return headers
 
 

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -203,19 +203,20 @@ class AjaxServer:
 
 
     def setHeader(self, name, value):
-        self.headers[name] = value
+        self.extraHeaders[name] = value
 
 
     def resetHeaders(self):
-        self.headers = {
-            'HTTP/1.1 200 OK': None,
-            'Content-Type': 'text/json'
-        }
+        self.headers = [
+            ['HTTP/1.1 200 OK', None],
+            ['Content-Type', 'text/json']
+        ]
+        self.extraHeaders = {}
 
 
     def getHeaders(self):
-        headers = []
-        for name in self.headers:
+        headers = self.headers
+        for name in self.extraHeaders:
             headers.append([name, self.headers[name]])
         return headers
 


### PR DESCRIPTION
> I am not a fan of the direct indexing in `headers[2][1] = str(len(body))`

How does this look? As well as being nicer to read, this will also prevent duplicate headers.

Sorry for the trailing spaces I keep leaving! I switched to Sublime Text today and I've enabled removing them on save so it shouldn't happen any more.

How's the new version system going? If you're working on other stuff more right now I could have a go implementing what you described.