### PR TITLE
Add storage actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,75 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ]
     ```
 
+*   **storeFile**
+
+    Stores a file with the specified base64-encoded contents inside the media folder. Returns `true` upon success or
+    `false` if attempting to write a file outside the media folder.
+
+    Note: to prevent Anki from removing files not used by any cards (e.g. for configuration files), prefix the filename
+    with an underscore. These files are still synchronized to AnkiWeb.
+
+    *Sample request*:
+    ```
+    {
+        "action": "storeFile",
+        "params": {
+            "filename": "_hello.txt",
+            "data": "SGVsbG8sIHdvcmxkIQ=="
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
+    ```
+
+    *Content of `_hello.txt`*:
+    ```
+    Hello world!
+    ```
+
+*   **retrieveFile**
+
+    Retrieves the base64-encoded contents of the specified file, returning `false` if the file does not exist or if
+    attempting to read a file outside the media folder.
+
+    *Sample request*:
+    ```
+    {
+        "action": "retrieveFile",
+        "params": {
+            "filename": "_hello.txt"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    "SGVsbG8sIHdvcmxkIQ=="
+    ```
+
+*   **deleteFile**
+
+    Deletes the specified file inside the media folder, returning `true` if successful, or `false` if the file does not
+    exist or if attempting to delete a file outside the media folder.
+
+    *Sample request*:
+    ```
+    {
+        "action": "deleteFile",
+        "params": {
+            "filename": "_hello.txt"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
+    ```
+
 *   **deckNames**
 
     Gets the complete list of deck names for the current user.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Categories:
 * [Card Suspension](#card-suspension)
 * [Card Intervals](#card-intervals)
 * [Finding Notes and Cards](#finding-notes-and-cards)
-* [File Storage](#file-storage)
+* [Media File Storage](#media-file-storage)
 * [Graphical](#graphical)
 
 ### Miscellaneous ###
@@ -853,12 +853,11 @@ Categories:
     ]
     ```
 
-### File Storage ###
+### Media File Storage ###
 
-*   **storeFile**
+*   **storeMediaFile**
 
-    Stores a file with the specified base64-encoded contents inside the media folder. Returns `true` upon success or
-    `false` if attempting to write a file outside the media folder.
+    Stores a file with the specified base64-encoded contents inside the media folder.
 
     Note: to prevent Anki from removing files not used by any cards (e.g. for configuration files), prefix the filename
     with an underscore. These files are still synchronized to AnkiWeb.
@@ -866,7 +865,7 @@ Categories:
     *Sample request*:
     ```
     {
-        "action": "storeFile",
+        "action": "storeMediaFile",
         "params": {
             "filename": "_hello.txt",
             "data": "SGVsbG8sIHdvcmxkIQ=="
@@ -876,7 +875,7 @@ Categories:
 
     *Sample response*:
     ```
-    true
+    null
     ```
 
     *Content of `_hello.txt`*:
@@ -884,15 +883,14 @@ Categories:
     Hello world!
     ```
 
-*   **retrieveFile**
+*   **retrieveMediaFile**
 
-    Retrieves the base64-encoded contents of the specified file, returning `false` if the file does not exist or if
-    attempting to read a file outside the media folder.
+    Retrieves the base64-encoded contents of the specified file, returning `false` if the file does not exist.
 
     *Sample request*:
     ```
     {
-        "action": "retrieveFile",
+        "action": "retrieveMediaFile",
         "params": {
             "filename": "_hello.txt"
         }
@@ -904,15 +902,14 @@ Categories:
     "SGVsbG8sIHdvcmxkIQ=="
     ```
 
-*   **deleteFile**
+*   **deleteMediaFile**
 
-    Deletes the specified file inside the media folder, returning `true` if successful, or `false` if the file does not
-    exist or if attempting to delete a file outside the media folder.
+    Deletes the specified file inside the media folder.
 
     *Sample request*:
     ```
     {
-        "action": "deleteFile",
+        "action": "deleteMediaFile",
         "params": {
             "filename": "_hello.txt"
         }
@@ -921,7 +918,7 @@ Categories:
 
     *Sample response*:
     ```
-    true
+    null
     ```
 
 ### Graphical ###

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ curl localhost:8765 -X POST -d '{"action": "version"}'
 
 Below is a list of currently supported actions. Requests with invalid actions or parameters will a return `null` result.
 
+Categories:
+
+* [Miscellaneous](#miscellaneous)
+* [Decks](#decks)
+* [Deck Configurations](#deck-configurations)
+* [Models](#models)
+* [Note Creation](#note-creation)
+* [Note Tags](#note-tags)
+* [Card Suspension](#card-suspension)
+* [Card Intervals](#card-intervals)
+* [Finding Notes and Cards](#finding-notes-and-cards)
+* [File Storage](#file-storage)
+* [Graphical](#graphical)
+
+### Miscellaneous ###
+
 *   **version**
 
     Gets the version of the API exposed by this plugin. Currently versions `1` through `4` are defined.
@@ -102,6 +118,24 @@ Below is a list of currently supported actions. Requests with invalid actions or
     *Sample response*:
     ```
     4
+    ```
+
+*   **upgrade**
+
+    Displays a confirmation dialog box in Anki asking the user if they wish to upgrade AnkiConnect to the latest version
+    from the project's [master branch](https://raw.githubusercontent.com/FooSoft/anki-connect/master/AnkiConnect.py) on
+    GitHub. Returns a boolean value indicating if the plugin was upgraded or not.
+
+    *Sample request*:
+    ```
+    {
+        "action": "upgrade"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
     ```
 
 *   **multi**
@@ -132,74 +166,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ]
     ```
 
-*   **storeFile**
-
-    Stores a file with the specified base64-encoded contents inside the media folder. Returns `true` upon success or
-    `false` if attempting to write a file outside the media folder.
-
-    Note: to prevent Anki from removing files not used by any cards (e.g. for configuration files), prefix the filename
-    with an underscore. These files are still synchronized to AnkiWeb.
-
-    *Sample request*:
-    ```
-    {
-        "action": "storeFile",
-        "params": {
-            "filename": "_hello.txt",
-            "data": "SGVsbG8sIHdvcmxkIQ=="
-        }
-    }
-    ```
-
-    *Sample response*:
-    ```
-    true
-    ```
-
-    *Content of `_hello.txt`*:
-    ```
-    Hello world!
-    ```
-
-*   **retrieveFile**
-
-    Retrieves the base64-encoded contents of the specified file, returning `false` if the file does not exist or if
-    attempting to read a file outside the media folder.
-
-    *Sample request*:
-    ```
-    {
-        "action": "retrieveFile",
-        "params": {
-            "filename": "_hello.txt"
-        }
-    }
-    ```
-
-    *Sample response*:
-    ```
-    "SGVsbG8sIHdvcmxkIQ=="
-    ```
-
-*   **deleteFile**
-
-    Deletes the specified file inside the media folder, returning `true` if successful, or `false` if the file does not
-    exist or if attempting to delete a file outside the media folder.
-
-    *Sample request*:
-    ```
-    {
-        "action": "deleteFile",
-        "params": {
-            "filename": "_hello.txt"
-        }
-    }
-    ```
-
-    *Sample response*:
-    ```
-    true
-    ```
+### Decks ###
 
 *   **deckNames**
 
@@ -237,46 +204,71 @@ Below is a list of currently supported actions. Requests with invalid actions or
     }
     ```
 
-*   **modelNames**
+*   **getDecks**
 
-    Gets the complete list of model names for the current user.
-
-    *Sample request*:
-    ```
-    {
-        "action": "modelNames"
-    }
-    ```
-
-    *Sample response*:
-    ```
-    [
-        "Basic",
-        "Basic (and reversed card)"
-    ]
-    ```
-
-*   **modelFieldNames**
-
-    Gets the complete list of field names for the provided model name.
+    Accepts an array of card IDs and returns an object with each deck name as a key, and its value an array of the given
+    cards which belong to it.
 
     *Sample request*:
     ```
     {
-        "action": "modelFieldNames",
+        "action": "getDecks",
         "params": {
-            "modelName": "Basic"
+            "cards": [1502298036657, 1502298033753, 1502032366472]
         }
     }
     ```
 
     *Sample response*:
     ```
-    [
-        "Front",
-        "Back"
-    ]
+    {
+        "Default": [1502032366472],
+        "Japanese::JLPT N3": [1502298036657, 1502298033753]
+    }
     ```
+
+*   **changeDeck**
+
+    Moves cards with the given IDs to a different deck, creating the deck if it doesn't exist yet.
+
+    *Sample request*:
+    ```
+    {
+        "action": "changeDeck",
+        "params": {
+            "cards": [1502098034045, 1502098034048, 1502298033753],
+            "deck": "Japanese::JLPT N3"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    null
+    ```
+
+*   **deleteDecks**
+
+    Deletes decks with the given names. If `cardsToo` is `true` (defaults to `false` if unspecified), the cards within
+    the deleted decks will also be deleted; otherwise they will be moved to the default deck.
+
+    *Sample request*:
+    ```
+    {
+        "action": "deleteDecks",
+        "params": {
+            "decks": ["Japanese::JLPT N5", "Easy Spanish"],
+            "cardsToo": true
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    null
+    ```
+
+### Deck Configurations ###
 
 *   **getDeckConfig**
 
@@ -415,6 +407,51 @@ Below is a list of currently supported actions. Requests with invalid actions or
     true
     ```
 
+### Models ###
+
+*   **modelNames**
+
+    Gets the complete list of model names for the current user.
+
+    *Sample request*:
+    ```
+    {
+        "action": "modelNames"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    [
+        "Basic",
+        "Basic (and reversed card)"
+    ]
+    ```
+
+*   **modelFieldNames**
+
+    Gets the complete list of field names for the provided model name.
+
+    *Sample request*:
+    ```
+    {
+        "action": "modelFieldNames",
+        "params": {
+            "modelName": "Basic"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    [
+        "Front",
+        "Back"
+    ]
+    ```
+
+### Note Creation ###
+
 *   **addNote**
 
     Creates a note using the given deck and model, with the provided field values and tags. Returns the identifier of
@@ -530,6 +567,8 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ]
     ```
 
+### Note Tags ###
+
 *   **addTags**
 
     Adds tags to notes by note ID.
@@ -569,6 +608,8 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ```
     null
     ```
+
+### Card Suspension ###
 
 *   **suspend**
 
@@ -628,6 +669,8 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ```
     [false, true]
     ```
+
+### Card Intervals ###
 
 *   **areDue**
 
@@ -689,6 +732,7 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ]
     ```
 
+### Finding Notes and Cards ###
 
 *   **findNotes**
 
@@ -736,71 +780,6 @@ Below is a list of currently supported actions. Requests with invalid actions or
     ]
     ```
 
-*   **getDecks**
-
-    Accepts an array of card IDs and returns an object with each deck name as a key, and its value an array of the given
-    cards which belong to it.
-
-    *Sample request*:
-    ```
-    {
-        "action": "getDecks",
-        "params": {
-            "cards": [1502298036657, 1502298033753, 1502032366472]
-        }
-    }
-    ```
-
-    *Sample response*:
-    ```
-    {
-        "Default": [1502032366472],
-        "Japanese::JLPT N3": [1502298036657, 1502298033753]
-    }
-    ```
-
-
-*   **changeDeck**
-
-    Moves cards with the given IDs to a different deck, creating the deck if it doesn't exist yet.
-
-    *Sample request*:
-    ```
-    {
-        "action": "changeDeck",
-        "params": {
-            "cards": [1502098034045, 1502098034048, 1502298033753],
-            "deck": "Japanese::JLPT N3"
-        }
-    }
-    ```
-
-    *Sample response*:
-    ```
-    null
-    ```
-
-*   **deleteDecks**
-
-    Deletes decks with the given names. If `cardsToo` is `true` (defaults to `false` if unspecified), the cards within
-    the deleted decks will also be deleted; otherwise they will be moved to the default deck.
-
-    *Sample request*:
-    ```
-    {
-        "action": "deleteDecks",
-        "params": {
-            "decks": ["Japanese::JLPT N5", "Easy Spanish"],
-            "cardsToo": true
-        }
-    }
-    ```
-
-    *Sample response*:
-    ```
-    null
-    ```
-
 *   **cardsToNotes**
 
     Returns an (unordered) array of note IDs for the given card IDs. For cards with the same note, the ID is only
@@ -823,6 +802,79 @@ Below is a list of currently supported actions. Requests with invalid actions or
         1502298025183
     ]
     ```
+
+### File Storage ###
+
+*   **storeFile**
+
+    Stores a file with the specified base64-encoded contents inside the media folder. Returns `true` upon success or
+    `false` if attempting to write a file outside the media folder.
+
+    Note: to prevent Anki from removing files not used by any cards (e.g. for configuration files), prefix the filename
+    with an underscore. These files are still synchronized to AnkiWeb.
+
+    *Sample request*:
+    ```
+    {
+        "action": "storeFile",
+        "params": {
+            "filename": "_hello.txt",
+            "data": "SGVsbG8sIHdvcmxkIQ=="
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
+    ```
+
+    *Content of `_hello.txt`*:
+    ```
+    Hello world!
+    ```
+
+*   **retrieveFile**
+
+    Retrieves the base64-encoded contents of the specified file, returning `false` if the file does not exist or if
+    attempting to read a file outside the media folder.
+
+    *Sample request*:
+    ```
+    {
+        "action": "retrieveFile",
+        "params": {
+            "filename": "_hello.txt"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    "SGVsbG8sIHdvcmxkIQ=="
+    ```
+
+*   **deleteFile**
+
+    Deletes the specified file inside the media folder, returning `true` if successful, or `false` if the file does not
+    exist or if attempting to delete a file outside the media folder.
+
+    *Sample request*:
+    ```
+    {
+        "action": "deleteFile",
+        "params": {
+            "filename": "_hello.txt"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    true
+    ```
+
+### Graphical ###
 
 *   **guiBrowse**
 
@@ -1011,24 +1063,6 @@ Below is a list of currently supported actions. Requests with invalid actions or
 		"params": {
 			"name": "Default"
 		}
-    }
-    ```
-
-    *Sample response*:
-    ```
-    true
-    ```
-
-*   **upgrade**
-
-    Displays a confirmation dialog box in Anki asking the user if they wish to upgrade AnkiConnect to the latest version
-    from the project's [master branch](https://raw.githubusercontent.com/FooSoft/anki-connect/master/AnkiConnect.py) on
-    GitHub. Returns a boolean value indicating if the plugin was upgraded or not.
-
-    *Sample request*:
-    ```
-    {
-        "action": "upgrade"
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -428,6 +428,27 @@ Categories:
     ]
     ```
 
+*   **modelNamesAndIds**
+
+    Gets the complete list of model names and their corresponding IDs for the current user.
+
+    *Sample request*:
+    ```
+    {
+        "action": "modelNamesAndIds"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    {
+        "Basic": 1483883011648
+        "Basic (and reversed card)": 1483883011644
+        "Basic (optional reversed card)": 1483883011631
+        "Cloze": 1483883011630
+    }
+    ```
+
 *   **modelFieldNames**
 
     Gets the complete list of field names for the provided model name.
@@ -448,6 +469,35 @@ Categories:
         "Front",
         "Back"
     ]
+    ```
+
+*   **modelFieldsOnTemplates**
+
+    Returns an object indicating the fields on the question and answer side of each card template for the given model
+    name. The question side is given first in each array.
+
+    *Sample request*:
+    ```
+    {
+        "action": "modelFieldsOnTemplates",
+        "params": {
+            "modelName": "Basic (and reversed card)"
+        }
+    }
+    ```
+
+    *Sample response*:
+    ```
+    {
+        "Card 1": [
+            ["Front"],
+            ["Back"]
+        ],
+        "Card 2": [
+            ["Back"],
+            ["Front"]
+        ]
+    }
     ```
 
 ### Note Creation ###


### PR DESCRIPTION
Reason for adding: I want to store settings for my app - like fields to test on for each note, testing options etc - in a way that it's saved between different browsers or even computers. By storing the JSON in the media folder, it's synced between different devices via AnkiWeb.

The underscore is required at the beginning of the filename to whitelist it, as otherwise Anki would otherwise warn that it's not used by any cards.

Should I try organizing the README? Now that we have lots more actions, I think it would be a good idea to separate them - e.g. a "Misc" header for stuff like `multi` and `version`, a "GUI" header for the GUI actions, a "Decks" header for `deckNames`, `deckNamesAndIds`, `getDeckConfig` etc...