### PR TITLE
Creating the guiExitAnki endpoint to allow closing Anki programmatically

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -850,6 +850,13 @@ class AnkiBridge:
         else:
             return False
 
+    def guiExitAnki(self):
+        timer = QTimer()
+        def exitAnki():
+            timer.stop()
+            self.window().close()
+        timer.timeout.connect(exitAnki)
+        timer.start(1000) # 1s should be enough to allow the response to be sent.
 
 #
 # AnkiConnect
@@ -1148,6 +1155,10 @@ class AnkiConnect:
     @webApi
     def guiDeckReview(self, name):
         return self.anki.guiDeckReview(name)
+
+    @webApi
+    def guiExitAnki(self):
+        return self.anki.guiExitAnki()
 
 
 #

--- a/README.md
+++ b/README.md
@@ -1119,6 +1119,21 @@ Categories:
     ```
     true
     ```
+*   **guiExitAnki**
+
+    Schedules a request to close Anki after 1s. This operation is asynchronous, so it will return immediately.
+
+    *Sample request*:
+    ```
+    {
+        "action": "guiExitAnki"
+    }
+    ```
+
+    *Sample response*:
+    ```
+    null
+    ```
 
 ## License ##
 

--- a/README.md
+++ b/README.md
@@ -1121,7 +1121,7 @@ Categories:
     ```
 *   **guiExitAnki**
 
-    Schedules a request to close Anki after 1s. This operation is asynchronous, so it will return immediately.
+    Schedules a request to close Anki after 1s. This operation is asynchronous, so it will return immediately and won't wait until Anki actually exits.
 
     *Sample request*:
     ```


### PR DESCRIPTION
It fixes https://github.com/FooSoft/anki-connect/issues/44.
I've used a timer to delay the closing for 1s.