### PR TITLE
Endpoint to get card/note fields and other data

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -762,7 +762,8 @@ class AnkiBridge:
                     'tags' : note.tags,
                     'fields': fields,
                     'modelName': model['name'],
-                    'cards': note.cards()
+                    'cards': self.collection().db.list(
+                        "select id from cards where nid = ? order by ord", self.id)
                 })
             except TypeError as e:
                 # Anki will give a TypeError if the note ID does not exist.

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -718,7 +718,7 @@ class AnkiBridge:
                 for info in model['flds']:
                     order = info['ord']
                     name = info['name']
-                    fields[name] = note.fields[order]
+                    fields[name] = {'value': note.fields[order], 'order': order}
             
                 result.append({
                     'cardId': card.id,
@@ -733,16 +733,6 @@ class AnkiBridge:
                     #This factor is 10 times the ease percentage, 
                     # so an ease of 310% would be reported as 3100
                     'interval': card.ivl,
-                    'type': card.type, 
-                    #new = 0, learning = 1, review = 2
-                    'queue': card.queue,
-                    # same as type, plus:
-                    # suspended = -1, user buried = -2, sched buried = -3
-                    'due': card.due,
-                    # does different things depending on queue,
-                    # new: position in queue
-                    # learning: integer timestamp
-                    # review: integer days (since first review)
                     'note': card.nid
                 })
             except TypeError as e:
@@ -765,13 +755,14 @@ class AnkiBridge:
                 for info in model['flds']:
                     order = info['ord']
                     name = info['name']
-                    fields[name] = note.fields[order]
+                    fields[name] = {'value': note.fields[order], 'order': order}
             
                 result.append({
                     'noteId': note.id,
                     'tags' : note.tags,
                     'fields': fields,
                     'modelName': model['name'],
+                    'cards': note.cards()
                 })
             except TypeError as e:
                 # Anki will give a TypeError if the note ID does not exist.

--- a/README.md
+++ b/README.md
@@ -1129,6 +1129,7 @@ guarantee that your application continues to function properly in the future.
         "action": "notesInfo",
         "version": 5,
         "params": {
+            "notes": [1502298033753]
         }
     }
     ```

--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,92 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
+*   **cardsInfo**
+
+    Returns a list of objects containing for each card ID the card fields, front and back sides including CSS, note type, the note that the card belongs to, and deck name, as well as ease and interval.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "cardsInfo",
+        "version": 5,
+        "params": {
+            "cards": [1498938915662, 1502098034048]
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": [
+            {
+                "answer": "back content",
+                "question": "front content",
+                "deckName": "Default",
+                "modelName": "Basic",
+                "fieldOrder": 1,
+                "fields": {
+                    "Front": {"value": "front content", "order": 0},
+                    "Back": {"value": "back content", "order": 1}
+                },
+                "css":"p {font-family:Arial;}",
+                "cardId": 1498938915662,
+                "interval": 16
+                "note":1502298033753
+            },
+            {
+                "answer": "back content",
+                "question": "front content",
+                "deckName": "Default",
+                "modelName": "Basic",
+                "fieldOrder": 0,
+                "fields": {
+                    "Front": {"value": "front content", "order": 0},
+                    "Back": {"value": "back content", "order": 1}
+                },
+                "css":"p {font-family:Arial;}",
+                "cardId": 1502098034048,
+                "interval": 23
+                "note":1502298033753
+            }
+        ],
+        "error": null
+    }
+    ```
+
+*   **notesInfo**
+
+    Returns a list of objects containing for each note ID the note fields, tags, note type and the cards belonging to the note.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "notesInfo",
+        "version": 5,
+        "params": {
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": [
+            {
+                "noteId":1502298033753,
+                "modelName": "Basic",
+                "tags":['tag','another_tag']
+                "fields": {
+                    "Front": {"value": "front content", "order": 0},
+                    "Back": {"value": "back content", "order": 1}
+                },
+            }
+        ],
+        "error": null
+    }
+    ```
+
 #### Media File Storage ####
 
 *   **storeMediaFile**

--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ guarantee that your application continues to function properly in the future.
             {
                 "noteId":1502298033753,
                 "modelName": "Basic",
+                "tags":["tag","another_tag"],
                 "fields": {
                     "Front": {"value": "front content", "order": 0},
                     "Back": {"value": "back content", "order": 1}

--- a/README.md
+++ b/README.md
@@ -1096,7 +1096,7 @@ guarantee that your application continues to function properly in the future.
                 },
                 "css":"p {font-family:Arial;}",
                 "cardId": 1498938915662,
-                "interval": 16
+                "interval": 16,
                 "note":1502298033753
             },
             {
@@ -1111,7 +1111,7 @@ guarantee that your application continues to function properly in the future.
                 },
                 "css":"p {font-family:Arial;}",
                 "cardId": 1502098034048,
-                "interval": 23
+                "interval": 23,
                 "note":1502298033753
             }
         ],
@@ -1141,7 +1141,6 @@ guarantee that your application continues to function properly in the future.
             {
                 "noteId":1502298033753,
                 "modelName": "Basic",
-                "tags":['tag','another_tag']
                 "fields": {
                     "Front": {"value": "front content", "order": 0},
                     "Back": {"value": "back content", "order": 1}


### PR DESCRIPTION
Adds two endpoints, which allow the user to retrieve the fields and other data of a list of cards or notes. I needed this feature myself to write a script that fetches data through AnkiConnect, and there's the open issue #51 requesting it, so I thought I might as well put in a PR.

I added only the card data that is relatively easy to use. Specifically, I didn't add card due dates, because Anki stores those internally in a kind of weird way and I don't know for sure if it's useful to report it like that (a next suggestion is maybe to add an endpoint to give a card's due date as a proper date stamp?).

The responses are mostly formatted like the existing `guiCurrentCard` endpoint, because its functionality is similar.