### PR TITLE
Expose Anki sync via AnkiConnect

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -948,7 +948,7 @@ class AnkiBridge:
         timer.start(1000) # 1s should be enough to allow the response to be sent.
 
     def sync(self):
-        self.window()._sync()
+        self.window().onSync()
 
 #
 # AnkiConnect

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -947,9 +947,13 @@ class AnkiBridge:
         timer.timeout.connect(exitAnki)
         timer.start(1000) # 1s should be enough to allow the response to be sent.
 
+    def sync(self):
+        self.window()._sync()
+
 #
 # AnkiConnect
 #
+
 
 class AnkiConnect:
     def __init__(self):
@@ -1280,6 +1284,11 @@ class AnkiConnect:
     @webApi()
     def notesInfo(self, notes):
         return self.anki.notesInfo(notes)
+
+    @webApi()
+    def sync(self):
+        return self.anki.sync()
+
 
 #
 #   Entry

--- a/README.md
+++ b/README.md
@@ -191,6 +191,27 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
+*   **sync**
+
+    Synchronizes the local anki collections with ankiweb.
+    
+    *Sample request*:
+    ```json
+    {
+        "action": "sync",
+        "version": 5
+
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": null,
+        "error": null
+    }
+
+
 *   **multi**
 
     Performs multiple actions in one request, returning an array with the response of each action (in the given order).


### PR DESCRIPTION
I tested this code on the command line with

```
curl localhost:8765 -X POST -d "{\"action\": \"sync\", \"version\": 5}"
```

When sync is thus invoked, the Anki app window becomes active (moves above other windows on the desktop).  After invoking sync when the Anki app is closed the collection corrupt error is thrown. See [here](https://github.com/dae/anki/blob/master/aqt/main.py#L384)

I am working with the Anki21 beta build