### PR TITLE
Catch exception when checking if a note can be created

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -401,7 +401,10 @@ class AnkiBridge:
 
 
     def canAddNote(self, note):
-        return bool(self.createNote(note))
+        try:
+            return bool(self.createNote(note))
+        except:
+            return False
 
 
     def createNote(self, params):


### PR DESCRIPTION
Regular user with Yomichan here.
Noticed that the "+" button would not show if a card in the "canAddNotes" query already existed, and it seems to have been due to some exceptions that were added some time earlier in AnkiBridge.createNote().
Just made it so that AnkiBridge.canAddNote() catches any exception thrown there and returns False in those cases.