### PR TITLE
Change addNote auto fields parameter to array

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,9 @@ guarantee that your application continues to function properly in the future.
                     "url": "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php?kanji=猫&kana=ねこ",
                     "filename": "yomichan_ねこ_猫.mp3",
                     "skipHash": "7e2c2f954ef6051373ba916f000168dc",
-                    "fields": "Front"
+                    "fields": [
+                        "Front"
+                    ]
                 }
             }
         }
@@ -748,7 +750,9 @@ guarantee that your application continues to function properly in the future.
                         "url": "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php?kanji=猫&kana=ねこ",
                         "filename": "yomichan_ねこ_猫.mp3",
                         "skipHash": "7e2c2f954ef6051373ba916f000168dc",
-                        "fields": "Front"
+                        "fields": [
+                            "Front"
+                        ]
                     }
                 }
             ]


### PR DESCRIPTION
The "fields" parameter should be array instead of a string.

Just noticed the "auto" in title should be "audio". Reject my pull request and I will commit again if you think this mistake should not be pulled.