### PR TITLE
Add option to allow adding duplicate notes

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -449,11 +449,21 @@ class AnkiConnect:
             if name in ankiNote:
                 ankiNote[name] = value
 
+        allowDuplicate = False
+        if 'options' in note:
+          if 'allowDuplicate' in note['options']:
+            allowDuplicate = note['options']['allowDuplicate']
+            if type(allowDuplicate) is not bool:
+              raise Exception('option parameter \'allowDuplicate\' must be boolean')
+
         duplicateOrEmpty = ankiNote.dupeOrEmpty()
         if duplicateOrEmpty == 1:
             raise Exception('cannot create note because it is empty')
         elif duplicateOrEmpty == 2:
+          if not allowDuplicate:
             raise Exception('cannot create note because it is a duplicate')
+          else:
+            return ankiNote
         elif duplicateOrEmpty == False:
             return ankiNote
         else:

--- a/README.md
+++ b/README.md
@@ -685,7 +685,8 @@ guarantee that your application continues to function properly in the future.
     optional and can be omitted. If you choose to include it, the `url` and `filename` fields must be also defined. The
     `skipHash` field can be optionally provided to skip the inclusion of downloaded files with an MD5 hash that matches
     the provided value. This is useful for avoiding the saving of error pages and stub files. The `fields` member is a
-    list of fields that should play audio when the card is displayed in Anki.
+    list of fields that should play audio when the card is displayed in Anki. The 'allowDuplicate' member inside 'options'
+    group can be set to true to enable adding duplicate cards. Normally duplicate cards can not be added and trigger exception.   
 
     *Sample request*:
     ```json
@@ -699,6 +700,9 @@ guarantee that your application continues to function properly in the future.
                 "fields": {
                     "Front": "front content",
                     "Back": "back content"
+                },
+                "options": {
+                  "allowDuplicate": false
                 },
                 "tags": [
                     "yomichan"


### PR DESCRIPTION
Added a feature to allow adding duplicate notes. As requested here: https://github.com/FooSoft/anki-connect/issues/98

Duplicate notes can be added by enabling option inside a note like this:

```
{
    "action": "addNote",
    "version": 5,
    "params": {
        "note": {
            "deckName": "TestDeck",
            "modelName": "Basic",
            "fields":  ... ,
            "options": {
            	"allowDuplicate": true
            },
            "tags": ... ,
            "audio": ...
        }
    }
}
```

I also added a brief description of this option in README

