### PR TITLE
Bug fix, duplicate audio filenames

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -713,11 +713,11 @@ class AnkiConnect:
                     skip = skipHash == m.hexdigest()
 
                 if not skip:
+                    audioFilename = self.media().writeData(audio['filename'], data)
                     for field in audio['fields']:
                         if field in ankiNote:
-                            ankiNote[field] += u'[sound:{}]'.format(audio['filename'])
-
-                    self.media().writeData(audio['filename'], data)
+                            ankiNote[field] += u'[sound:{}]'.format(audioFilename)
+                            
             except Exception as e:
                 errorMessage = str(e).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 for field in audio['fields']:


### PR DESCRIPTION
Fix the bug where old file name was referenced in the audio field. 

The problem was, if the audio file we were trying to save already existed it got automatically saved with a different name (the number was appended to the end), but inside the card the incorrect old filename was referenced.