### PR TITLE
Add new createModel Api end point without documentation

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -32,7 +32,6 @@ from operator import itemgetter
 from time import time
 from unicodedata import normalize
 
-
 #
 # Constants
 #
@@ -849,8 +848,15 @@ class AnkiConnect:
 
 
     @api()
-    def createModel(self, modelName, inOrderFields, cardTemplates):
+    def createModel(self, modelName, inOrderFields, cardTemplates, css = None):
         # https://github.com/dae/anki/blob/b06b70f7214fb1f2ce33ba06d2b095384b81f874/anki/stdmodels.py
+        if (len(inOrderFields) == 0):
+            raise Exception('Must provide at least one field for inOrderFields')
+        if (len(cardTemplates) == 0):
+            raise Exception('Must provide at least one card for cardTemplates')
+        if (modelName in self.collection().models.allNames()):
+            raise Exception('Model name already exists')
+
         collection = self.collection()
         mm = collection.models
 
@@ -861,8 +867,11 @@ class AnkiConnect:
         for field in inOrderFields:
             fm = mm.newField(_(field))
             mm.addField(m, fm)
+        
+        # Add shared css to model if exists. Use default otherwise
+        if (css is not None):
+            m['css'] = css
 
-        # TODO? => There is no validation that card fields are used correctly
         # Generate new card template(s)
         cardCount = 1
         for card in cardTemplates:

--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -849,6 +849,34 @@ class AnkiConnect:
 
 
     @api()
+    def createModel(self, modelName, inOrderFields, cardTemplates):
+        # https://github.com/dae/anki/blob/b06b70f7214fb1f2ce33ba06d2b095384b81f874/anki/stdmodels.py
+        collection = self.collection()
+        mm = collection.models
+
+        # Generate new Note
+        m = mm.new(_(modelName))
+
+        # Create fields and add them to Note
+        for field in inOrderFields:
+            fm = mm.newField(_(field))
+            mm.addField(m, fm)
+
+        # TODO? => There is no validation that card fields are used correctly
+        # Generate new card template(s)
+        cardCount = 1
+        for card in cardTemplates:
+            t = mm.newTemplate(_('Card ' + str(cardCount)))
+            cardCount += 1
+            t['qfmt'] = card['Front']
+            t['afmt'] = card['Back']
+            mm.addTemplate(m, t)
+
+        mm.add(m)
+        return m
+
+
+    @api()
     def modelNamesAndIds(self):
         models = {}
         for model in self.modelNames():

--- a/README.md
+++ b/README.md
@@ -727,6 +727,101 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
+
+    **Create new Model**
+
+    Creates a new model to be used in Anki. User must provide modelName, inOrderFields and cardTemplates to be used
+    in the model.
+
+    *Sample request*
+    ```json
+    {
+        "action": "createNewModel",
+        "version": 6,
+        "params": {
+            "modelName": "newModelName",
+            "inOrderFields": ["Field1", "Field2", "Field3"], 
+            "css": "Optional CSS with default to builtin css",
+            "cardTemplates": [
+                {
+                    "Front": "Front html {{Field1}}",
+                    "Back": "Back html  {{Field2}}"
+                }
+            ]
+        }
+    }
+    ```
+
+    *Sample result*
+    ```json
+    {
+        "result":{
+            "sortf":0,
+            "did":1,
+            "latexPre":"\\documentclass[12pt]{article}\n\\special{papersize=3in,5in}\n\\usepackage[utf8]{inputenc}\n\\usepackage{amssymb,amsmath}\n\\pagestyle{empty}\n\\setlength{\\parindent}{0in}\n\\begin{document}\n",
+            "latexPost":"\\end{document}",
+            "mod":1551462107,
+            "usn":-1,
+            "vers":[
+
+            ],
+            "type":0,
+            "css":".card {\n font-family: arial;\n font-size: 20px;\n text-align: center;\n color: black;\n background-color: white;\n}\n",
+            "name":"TestApiModel",
+            "flds":[
+                {
+                    "name":"Field1",
+                    "ord":0,
+                    "sticky":false,
+                    "rtl":false,
+                    "font":"Arial",
+                    "size":20,
+                    "media":[
+
+                    ]
+                },
+                {
+                    "name":"Field2",
+                    "ord":1,
+                    "sticky":false,
+                    "rtl":false,
+                    "font":"Arial",
+                    "size":20,
+                    "media":[
+
+                    ]
+                }
+            ],
+            "tmpls":[
+                {
+                    "name":"Card 1",
+                    "ord":0,
+                    "qfmt":"",
+                    "afmt":"This is the back of the card {{Field2}}",
+                    "did":null,
+                    "bqfmt":"",
+                    "bafmt":""
+                }
+            ],
+            "tags":[
+
+            ],
+            "id":"1551462107104",
+            "req":[
+                [
+                    0,
+                    "none",
+                    [
+
+                    ]
+                ]
+            ]
+        },
+        "error":null
+    }
+    ```
+
+
 #### Notes ####
 
 *   **addNote**

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,6 +20,11 @@ class TestModels(unittest.TestCase):
         # modelFieldsOnTemplates
         modelFieldsOnTemplates = util.invoke('modelFieldsOnTemplates', modelName=modelNames[0])
 
+        # createModel with css
+        newModel = util.invoke('createModel', modelName='testModel', inOrderFields=['field1', 'field2'], cardTemplates=[{'Front':'field1','Back':'field2'}], css='some random css')
+
+        # createModel without css
+        newModel = util.invoke('createModel', modelName='testModel-second', inOrderFields=['field1', 'field2'], cardTemplates=[{'Front':'field1','Back':'field2'}])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Pull request for issue #100 .

I am opening this pull request for @FooSoft review. If you like the over all format I will update it with documentation for the readme.

If you want any overall changes let me know.

Code was mainly built using:
        https://github.com/dae/anki/blob/b06b70f7214fb1f2ce33ba06d2b095384b81f874/anki/stdmodels.py

As referenced in my comment api endpoint is as follow:

inOrderField: (1-n) (Do we want to throw an error if at least 1 value it not present?)
cardTemplate: (1-n) (Do we want to throw an error if at least 1 value it not present?)
``` json
{
    "action": "createNewModel",
    "version": 6,
    "params": {
        "modelName": "newModelName",
        "inOrderFields": ["Field1", "Field2", "Field3"], 
        "cardTemplates": [
            {
                "Front": "Front htm {{Field1}}l",
                "Back": "Back html  {{Field2}}",
                "Css": "Optional CSS and default to builtin css",
            }
        ]
    }
}
``` 

Questions:

- [ ] Overall API issues

- [ ] Throw error if correct numbers not present? (cardTemplates / inOrderFields)

- [ ] Does the back and front need to validate fields are actually used?

- [ ] Any formatting changes

- [ ] Default CSS options or not?



