### PR TITLE
Add next review times when returning data in guiCurrentCard

### DIFF
--- a/AnkiConnect.py
+++ b/AnkiConnect.py
@@ -1277,13 +1277,15 @@ class AnkiConnect:
             fields[name] = {'value': note.fields[order], 'order': order}
 
         if card is not None:
+            buttonList = reviewer._answerButtonList()
             return {
                 'cardId': card.id,
                 'fields': fields,
                 'fieldOrder': card.ord,
                 'question': card._getQA()['q'],
                 'answer': card._getQA()['a'],
-                'buttons': [b[0] for b in reviewer._answerButtonList()],
+                'buttons': [b[0] for b in buttonList],
+                'nextReviews': [reviewer.mw.col.sched.nextIvlStr(reviewer.card, b[0], True) for b in buttonList],
                 'modelName': model['name'],
                 'deckName': self.deckNameFromId(card.did),
                 'css': model['css'],

--- a/README.md
+++ b/README.md
@@ -1555,7 +1555,8 @@ guarantee that your application continues to function properly in the future.
             },
             "template": "Forward",
             "cardId": 1498938915662,
-            "buttons": [1, 2, 3]
+            "buttons": [1, 2, 3],
+            "nextReviews": ["<1m", "<10m", "4d"]
         },
         "error": null
     }


### PR DESCRIPTION
A user requested a feature in corollari/ankiTab#19 that would require being able to obtain the times for the next review assigned to each button. This pull request adds a new data field to guiCurrentCard that retrieves that information.

As nothing else is modified, this is backwards compatible with the current version of the API.