### PR TITLE
Add support for multiple cors origins

### DIFF
--- a/plugin/config.json
+++ b/plugin/config.json
@@ -3,5 +3,5 @@
     "apiLogPath": null,
     "webBindAddress": "127.0.0.1",
     "webBindPort": 8765,
-    "webCorsOrigin": "http://localhost"
+    "webCorsOrigin": ["http://localhost"]
 }

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -3,5 +3,6 @@
     "apiLogPath": null,
     "webBindAddress": "127.0.0.1",
     "webBindPort": 8765,
-    "webCorsOrigin": ["http://localhost"]
+    "webCorsOrigin": "http://localhost",
+    "webCorsOriginList": ["http://localhost"]
 }

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -54,6 +54,7 @@ def setting(key):
         'webBindAddress':  os.getenv('ANKICONNECT_BIND_ADDRESS', '127.0.0.1'),
         'webBindPort':     8765,
         'webCorsOrigin':   os.getenv('ANKICONNECT_CORS_ORIGIN', 'http://localhost'),
+        'webCorsOriginList': ['http://localhost'],
         'webTimeout':      10000,
     }
 

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -154,13 +154,19 @@ class WebServer:
                 body = json.dumps(None).encode('utf-8')
 
         # handle multiple cors origins by checking the 'origin'-header against the allowed origin list from the config
-        webCorsOriginsSetting = util.setting('webCorsOrigin')
-        corsOrigin = "http://localhost"
-        if len(webCorsOriginsSetting) == 1:
-            corsOrigin = webCorsOriginsSetting[0]
-        elif b"origin" in req.headers:
-            originStr = req.headers[b"origin"].decode()
-            if originStr in webCorsOriginsSetting:
+        webCorsOriginList = util.setting('webCorsOriginList')
+
+        # keep support for deprecated 'webCorsOrigin' field, as long it is not removed
+        webCorsOrigin = util.setting('webCorsOrigin')
+        if webCorsOrigin:
+            webCorsOriginList.append(webCorsOrigin)
+
+        corsOrigin = 'http://localhost'
+        if len(webCorsOriginList) == 1:
+            corsOrigin = webCorsOriginList[0]
+        elif b'origin' in req.headers:
+            originStr = req.headers[b'origin'].decode()
+            if originStr in webCorsOriginList:
                 corsOrigin = originStr
 
         headers = [

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -153,10 +153,20 @@ class WebServer:
             except ValueError:
                 body = json.dumps(None).encode('utf-8')
 
+        # handle multiple cors origins by checking the 'origin'-header against the allowed origin list from the config
+        webCorsOriginsSetting = util.setting('webCorsOrigin')
+        corsOrigin = "http://localhost"
+        if len(webCorsOriginsSetting) == 1:
+            corsOrigin = webCorsOriginsSetting[0]
+        elif b"origin" in req.headers:
+            originStr = req.headers[b"origin"].decode()
+            if originStr in webCorsOriginsSetting:
+                corsOrigin = originStr
+
         headers = [
             ['HTTP/1.1 200 OK', None],
             ['Content-Type', 'text/json'],
-            ['Access-Control-Allow-Origin', util.setting('webCorsOrigin')],
+            ['Access-Control-Allow-Origin', corsOrigin],
             ['Content-Length', str(len(body))]
         ]
 


### PR DESCRIPTION
Add support for configuring multiple cors origins by using the *origin* request-header and comparing its value to the configured cors origins.