### PR TITLE
Make guiAddCards have a return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,6 +1594,8 @@ guarantee that your application continues to function properly in the future.
     The `closeAfterAdding` member inside `options` group can be set to true to create a dialog that closes upon adding the note.
     Invoking the action mutliple times with this option will create _multiple windows_.
 
+    The result is the ID of the note which would be added, if the user chose to confirm the *Add Cards* dialogue.
+
     *Sample request*:
     ```json
     {
@@ -1621,7 +1623,7 @@ guarantee that your application continues to function properly in the future.
     *Sample result*:
     ```json
     {
-        "result": null,
+        "result": 1496198395707,
         "error": null
     }
     ```

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -977,6 +977,8 @@ class AnkiConnect:
             aqt.dialogs.open(windowName, self.window())
             addCards.setAndFocusNote(editor.note)
 
+            return ankiNote.id
+
         elif note is not None:
             currentWindow = aqt.dialogs._dialogs['AddCards'][1]
 
@@ -1011,9 +1013,13 @@ class AnkiConnect:
             else:
                 openNewWindow()
 
+            return aqt.dialogs._dialogs['AddCards'][1].editor.note.id
+
         else:
             addCards = aqt.dialogs.open('AddCards', self.window())
             addCards.activateWindow()
+
+            return addCards.editor.note.id
 
     @util.api()
     def guiReviewActive(self):


### PR DESCRIPTION
This addresses issues #115 (as well as #135).

`guiAddCards` now returns the only value, it can logically return: The note id of the note, which *were* to be added, if the user confirmed the add dialogue.