### PR TITLE
Accept multiple audio files in note creation and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,12 +926,12 @@ guarantee that your application continues to function properly in the future.
     the created note created on success, and `null` on failure.
 
     AnkiConnect can download audio files and embed them in newly created notes. The corresponding `audio` note member is
-    optional and can be omitted. If you choose to include it, the `url` and `filename` fields must be also defined. The
-    `skipHash` field can be optionally provided to skip the inclusion of downloaded files with an MD5 hash that matches
-    the provided value. This is useful for avoiding the saving of error pages and stub files. The `fields` member is a
-    list of fields that should play audio when the card is displayed in Anki. The `allowDuplicate` member inside
-    `options` group can be set to true to enable adding duplicate cards. Normally duplicate cards can not be added and
-    trigger exception.
+    optional and can be omitted. If you choose to include it, it should contain a single object or an array of objects
+    with mandatory `url` and `filename` fields. The `skipHash` field can be optionally provided to skip the inclusion of
+    downloaded files with an MD5 hash that matches the provided value. This is useful for avoiding the saving of error
+    pages and stub files. The `fields` member is a list of fields that should play audio when the card is displayed in
+    Anki. The `allowDuplicate` member inside `options` group can be set to true to enable adding duplicate cards.
+    Normally duplicate cards can not be added and trigger exception.
 
     *Sample request*:
     ```json
@@ -952,14 +952,14 @@ guarantee that your application continues to function properly in the future.
                 "tags": [
                     "yomichan"
                 ],
-                "audio": {
+                "audio": [{
                     "url": "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php?kanji=猫&kana=ねこ",
                     "filename": "yomichan_ねこ_猫.mp3",
                     "skipHash": "7e2c2f954ef6051373ba916f000168dc",
                     "fields": [
                         "Front"
                     ]
-                }
+                }]
             }
         }
     }
@@ -996,14 +996,14 @@ guarantee that your application continues to function properly in the future.
                     "tags": [
                         "yomichan"
                     ],
-                    "audio": {
+                    "audio": [{
                         "url": "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php?kanji=猫&kana=ねこ",
                         "filename": "yomichan_ねこ_猫.mp3",
                         "skipHash": "7e2c2f954ef6051373ba916f000168dc",
                         "fields": [
                             "Front"
                         ]
-                    }
+                    }]
                 }
             ]
         }
@@ -1056,7 +1056,8 @@ guarantee that your application continues to function properly in the future.
 
 *   **updateNoteFields**
 
-    Modify the fields of an exist note.
+    Modify the fields of an exist note. You can also include audio files which will be added to the note with an
+    optional `audio` property. Please see the documentation for `addNote` for an explanation of objects in the `audio` array.
 
     *Sample request*:
     ```json
@@ -1069,7 +1070,15 @@ guarantee that your application continues to function properly in the future.
                 "fields": {
                     "Front": "new front content",
                     "Back": "new back content"
-                }
+                },
+                "audio": [{
+                    "url": "https://assets.languagepod101.com/dictionary/japanese/audiomp3.php?kanji=猫&kana=ねこ",
+                    "filename": "yomichan_ねこ_猫.mp3",
+                    "skipHash": "7e2c2f954ef6051373ba916f000168dc",
+                    "fields": [
+                        "Front"
+                    ]
+                }]
             }
         }
     }

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -485,7 +485,7 @@ class AnkiConnect:
                                     ankiNote[field] += u'[sound:{}]'.format(audioFilename)
 
                     except Exception as e:
-                        errorMessage = str(e).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                        errorMessage = str(e).replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
                         for field in audio['fields']:
                             if field in ankiNote:
                                 ankiNote[field] += errorMessage


### PR DESCRIPTION
Hi there,

First of all thank you so much for offering this plugin and the awesome work that you put into this.

This commit changes the API to accept an array of audio files instead of a single object.

Example:

``` json
{
    "action": "addNote",
    "version": 6,
    "params": {
        "note": {
            "audio": [{
                "url": "https://www.oxfordlearnersdictionaries.com/media/english/uk_pron/s/ser/seren/serendipity__gb_1.mp3",
                "filename": "oald_serendipity__gb_1.mp3",
                "fields": ["Audio"]
            }, {
                "url": "https://www.oxfordlearnersdictionaries.com/media/english/uk_pron/s/ser/seren/serendipity__us_2.mp3",
                "filename": "oald_serendipity__us_2.mp3",
                "fields": ["Audio"]
            }]
        }
    }
}
```

It also extends the API for the note update (`updateNoteFields`) to accept an array (or a single object) for audio file(s). Previously there was no support for adding audio after the note has been created.

I hope this is useful for other users too.

Let me know if I should document this in the readme.