### PR TITLE
Add card name option in model template

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,7 +709,8 @@ guarantee that your application continues to function properly in the future.
 *   **createModel**
 
     Creates a new model to be used in Anki. User must provide the `modelName`, `inOrderFields` and `cardTemplates` to be
-    used in the model.
+    used in the model. Optionally the `Name` field can be provided for each entry of `cardTemplates`. By default the
+    card names will be `Card 1`, `Card 2`, and so on.
 
     *Sample request*
     ```json
@@ -722,6 +723,7 @@ guarantee that your application continues to function properly in the future.
             "css": "Optional CSS with default to builtin css",
             "cardTemplates": [
                 {
+                    "Name": "My Card 1",
                     "Front": "Front html {{Field1}}",
                     "Back": "Back html  {{Field2}}"
                 }
@@ -772,7 +774,7 @@ guarantee that your application continues to function properly in the future.
             ],
             "tmpls":[
                 {
-                    "name":"Card 1",
+                    "name":"My Card 1",
                     "ord":0,
                     "qfmt":"",
                     "afmt":"This is the back of the card {{Field2}}",

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -642,7 +642,11 @@ class AnkiConnect:
         # Generate new card template(s)
         cardCount = 1
         for card in cardTemplates:
-            t = mm.newTemplate(anki.lang._('Card ' + str(cardCount)))
+            cardName = 'Card ' + str(cardCount)
+            if 'Name' in card:
+                cardName = card['Name']
+
+            t = mm.newTemplate(anki.lang._(cardName))
             cardCount += 1
             t['qfmt'] = card['Front']
             t['afmt'] = card['Back']


### PR DESCRIPTION
This PR adds an `Name` field to entries of `cardTemplates` so that the user is able to
configure the card names. By default the card name are still `Card 1`, `Card 2`, and so on.

**Example**:
```json
"cardTemplates": [
        {
            "Name": "Meaning",
            "Front": "(...)",
            "Back": "(...)"
        },
        {
            "Name": "Writing",
            "Front": "(...)",
            "Back": "(...)"
        }
]
```

![Screenshot from 2020-03-13 23-54-22](https://user-images.githubusercontent.com/28662686/76664857-fee99c80-6585-11ea-9a43-6c551322f394.png)
