### PR TITLE
Supports profile specific configuration

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -60,9 +60,8 @@ class AnkiConnect:
             QMessageBox.critical(
                 self.window(),
                 'AnkiConnect',
-                'Failed to listen on port {}.\nMake sure it is available and is not in use.'.format(util.setting('webBindPort'))
+                'Failed to listen on port {}.\nMake sure it is available and is not in use.'.format(self.server.port)
             )
-
 
     def logEvent(self, name, data):
         if self.log is not None:
@@ -1227,3 +1226,6 @@ class AnkiConnect:
 #
 
 ac = AnkiConnect()
+
+from anki.hooks import addHook
+addHook("profileLoaded", ac.__init__)

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -4,5 +4,13 @@
     "webBindAddress": "127.0.0.1",
     "webBindPort": 8765,
     "webCorsOrigin": "http://localhost",
-    "webCorsOriginList": ["http://localhost"]
+    "webCorsOriginList": ["http://localhost"],
+    "profiles":{
+        "user1": {
+            "webBindPort": 8766
+        },
+        "user2": {
+            "webBindPort": 8767
+        }
+    }
 }

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -58,7 +58,11 @@ def setting(key):
         'webTimeout': 10000,
     }
 
+    config = aqt.mw.addonManager.getConfig(__name__)
+    if 'profiles' in config and aqt.mw.pm.name in config['profiles']:
+        config.update(config['profiles'][aqt.mw.pm.name])
+
     try:
-        return aqt.mw.addonManager.getConfig(__name__).get(key, defaults[key])
+        return config.get(key, defaults[key])
     except:
         raise Exception('setting {} not found'.format(key))

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -139,7 +139,8 @@ class WebServer:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.setblocking(False)
-        self.sock.bind((util.setting('webBindAddress'), util.setting('webBindPort')))
+        self.port = util.setting('webBindPort')
+        self.sock.bind((util.setting('webBindAddress'), self.port))
         self.sock.listen(util.setting('webBacklog'))
 
 


### PR DESCRIPTION
I needed this, because my external program has also profile like feature and I wanted to distinguish them completely. This was specially useful when there are multiple anki instances (I forked anki and made some change).

Then I thought, there could be broader use case.