### PR TITLE
Add REST interface for file retrieval

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -435,7 +435,7 @@ class AnkiConnect:
             raise Exception('You must either provide a "data" or a "url" field.')
 
     @util.api()
-    def retrieveMediaFile(self, filename):
+    def retrieveMediaFile(self, filename, encoding="base64"):
         filename = os.path.basename(filename)
         filename = unicodedata.normalize('NFC', filename)
         filename = self.media().stripIllegal(filename)
@@ -443,7 +443,7 @@ class AnkiConnect:
         path = os.path.join(self.media().dir(), filename)
         if os.path.exists(path):
             with open(path, 'rb') as file:
-                return base64.b64encode(file.read()).decode('ascii')
+                return base64.b64encode(file.read()).decode('ascii') if encoding == "base64" else file.read()
 
         return False
 

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -145,7 +145,22 @@ class WebServer:
 
     def handlerWrapper(self, req):
         if len(req.body) == 0:
-            body = 'AnkiConnect v.{}'.format(util.setting('apiVersion')).encode('utf-8')
+            try:
+                filename = list(req.headers)[0].decode('utf-8').split()[1]
+                if filename == "/":
+                    body = 'AnkiConnect v.{}'.format(util.setting('apiVersion')).encode('utf-8')
+                else:
+                    print(filename)
+                    params = {
+                            "action": "retrieveMediaFile",
+                            "params": {
+                                "filename": filename,
+                                "encoding": "none"
+                            }
+                        }
+                    body = self.handler(params)
+            except:
+                body = json.dumps(None).encode('utf-8')
         else:
             try:
                 params = json.loads(req.body.decode('utf-8'))


### PR DESCRIPTION
When displaying cards outside of anki, getting the files embedded inside them to work properly has given me quite a lot of trouble, as right now this requires parsing the html document, requesting the files through the API and then embedding them into the document for display. This has been a constant source of problems due to the high variety of corner cases that appear when parsing, and the possibility of javascript being involved complicates everything to the extreme. 

This PR aims to solve that problem by providing another interface for retrieveMediaFile, one that essentially serves these files as a webserver. This will make it so html can be dumped on any browser-like system and the files will be automatically requested by that same browser.

**Note**: I'm not quite satisfied with the code quality of this PR, I think the conditionals I've introduced in web.py are a bit convoluted (I've spent like 2 hours trying to refactor but haven't come up with a better solution, suggestions are welcome!) and it's lacking some error handling, but I've submitted this PR to get the conversation started on this specific change. 