### PR TITLE
Use new hook for delete

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -429,6 +429,7 @@ class AnkiConnect:
             self.deleteMediaFile(filename)
             self.media().writeData(filename, base64.b64decode(data))
         elif url:
+            self.deleteMediaFile(filename)
             downloadedData = util.download(url)
             self.media().writeData(filename, downloadedData)
         else:
@@ -450,7 +451,10 @@ class AnkiConnect:
 
     @util.api()
     def deleteMediaFile(self, filename):
-        self.media().syncDelete(filename)
+        try:
+            self.media().syncDelete(filename)
+        except AttributeError:
+            self.media().trash_files([filename])
 
 
     @util.api()


### PR DESCRIPTION
In reference to issue #146 

Also added the `deleteMediaFile` when dealing with urls. 

The new functionality of `writeData` means that is there is a name conflict it will rename the file. This way the behavior of your api does not change.

Only potential issues I see with this is that the file is `trashed` but not deleted. So is only cleared up on the usual clear up.

Test locally using my own Anki install at `2.1.22` and POST man to create new media