### PR TITLE
add api to get number of cards reviewed in the current day

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,26 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
+*   **getNumCardsReviewedToday**
+
+    Gets the count of cards that have been reviewed in the current day (with day start time as configured by user in anki)
+
+    *Sample request*:
+    ```json
+    {
+        "action": "getNumCardsReviewedToday",
+        "version": 6
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": 0,
+        "error": null
+    }
+    ```
+
 #### Decks ####
 
 *   **deckNames**

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -285,6 +285,11 @@ class AnkiConnect:
         return list(map(self.handler, actions))
 
 
+    @util.api()
+    def getNumCardsReviewedToday(self):
+        return self.database().scalar('select count() from revlog where id > ?', (self.scheduler().dayCutoff - 86400) * 1000)
+    
+
     #
     # Decks
     #

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,6 +20,10 @@ class TestMisc(unittest.TestCase):
             self.assertIsNone(result['error'])
             self.assertEqual(result['result'], 6)
 
+        # getNumCardsReviewedToday
+        result = util.invoke('getNumCardsReviewedToday')
+        self.assertIsInstance(result, int)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
partly addresses issue raised in #117
(being able to get number of cards reviewed in the current day allows one to use AnkiConnect for automation for things like blocking websites etc until a certain number of cards have been reviewed everyday etc)