### PR TITLE
Import package

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,30 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
+*   **importPackage**
+
+    Imports a file in `.apkg` format into the collection. Returns `true` if successful or `false` otherwise.
+    Note that the file path is relative to Anki's collection.media folder, not to the client.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "importPackage",
+        "version": 6,
+        "params": {
+            "path": "/data/Deck.apkg",
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": true,
+        "error": null
+    }
+    ```
+
 #### Decks
 
 *   **deckNames**

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -34,6 +34,7 @@ import anki.lang
 import anki.storage
 import aqt
 from anki.exporting import AnkiPackageExporter
+from anki.importing import AnkiPackageImporter
 
 from . import web, util
 
@@ -1215,6 +1216,22 @@ class AnkiConnect:
                 return True
         return False
 
+    @util.api()
+    def importPackage(self, path):
+        collection = self.collection()
+        if collection is not None:
+            try:
+                self.startEditing()
+                importer = AnkiPackageImporter(collection, path)
+                importer.run()
+            except:
+                self.stopEditing()
+                raise
+            else:
+                self.stopEditing()
+                return True
+
+        return False
 
 #
 # Entry

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -34,6 +34,20 @@ class TestMisc(unittest.TestCase):
         self.assertTrue(result)
         self.assertTrue(os.path.exists(newname))
 
+        # importPackage
+        deckName = 'importTest'
+        fd, newname = tempfile.mkstemp(prefix='testimport', suffix='.apkg')
+        os.close(fd)
+        os.unlink(newname)
+        util.invoke('createDeck', deck=deckName)
+        note = {'deckName': deckName, 'modelName': 'Basic', 'fields': {'Front': 'front1', 'Back': 'back1'}, 'tags': ''}
+        noteId = util.invoke('addNote', note=note)
+        util.invoke('exportPackage', deck=deckName, path=newname)
+        util.invoke('deleteDecks', decks=[deckName], cardsToo=True)
+        util.invoke('importPackage', path=newname)
+        deckNames = util.invoke('deckNames')
+        self.assertIn(deckName, deckNames)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add an importPackage to complement exportPackage.

The motivation for this and the getProfiles PR #159 are to support cases like a teacher who has access to all their student's profiles, and wishes to automate looping through them all to import a deck or to sync the Leaderboard add-on.

https://www.reddit.com/r/Anki/comments/ga6zdp/using_anki_in_schools_or_bulding_an_alternative/