### PR TITLE
Collection stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,14 +370,14 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
-*   **getCollectionStats**
+*   **getCollectionStatsHTML**
 
     Gets the collection statistics report
 
     *Sample request*:
     ```json
     {
-        "action": "getCollectionStats",
+        "action": "getCollectionStatsHTML",
         "version": 6
     }
     ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ with the latest stable (2.1.x) releases of Anki; older versions (2.0.x and below
     *   [Sample Invocation](#sample-invocation)
     *   [Supported Actions](#supported-actions)
         *   [Miscellaneous](#miscellaneous)
+        *   [Statistics](#statistics)
         *   [Decks](#decks)
         *   [Models](#models)
         *   [Notes](#notes)
@@ -297,26 +298,6 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
-*   **getNumCardsReviewedToday**
-
-    Gets the count of cards that have been reviewed in the current day (with day start time as configured by user in anki)
-
-    *Sample request*:
-    ```json
-    {
-        "action": "getNumCardsReviewedToday",
-        "version": 6
-    }
-    ```
-
-    *Sample result*:
-    ```json
-    {
-        "result": 0,
-        "error": null
-    }
-    ```
-
 *   **exportPackage**
 
     Exports a given deck in `.apkg` format. Returns `true` if successful or `false` otherwise. The optional property
@@ -364,6 +345,48 @@ guarantee that your application continues to function properly in the future.
     {
         "result": true,
         "error": null
+    }
+    ```
+
+#### Statistics
+
+*   **getNumCardsReviewedToday**
+
+    Gets the count of cards that have been reviewed in the current day (with day start time as configured by user in anki)
+
+    *Sample request*:
+    ```json
+    {
+        "action": "getNumCardsReviewedToday",
+        "version": 6
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": 0,
+        "error": null
+    }
+    ```
+
+*   **collectionStats**
+
+    Gets the collection statistics report
+
+    *Sample request*:
+    ```json
+    {
+        "action": "collectionStats",
+        "version": 6
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "error": null
+        "result": "<center> lots of HTML here </center>",
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ guarantee that your application continues to function properly in the future.
     *Sample result*:
     ```json
     {
-        "error": null
+        "error": null,
         "result": "<center> lots of HTML here </center>",
     }
     ```

--- a/README.md
+++ b/README.md
@@ -370,14 +370,14 @@ guarantee that your application continues to function properly in the future.
     }
     ```
 
-*   **collectionStats**
+*   **getCollectionStats**
 
     Gets the collection statistics report
 
     *Sample request*:
     ```json
     {
-        "action": "collectionStats",
+        "action": "getCollectionStats",
         "version": 6
     }
     ```

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -299,7 +299,7 @@ class AnkiConnect:
 
 
     @util.api()
-    def getCollectionStats(self):
+    def getCollectionStatsHTML(self):
         return self.collection().stats().report()
 
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -299,7 +299,7 @@ class AnkiConnect:
 
 
     @util.api()
-    def collectionStats(self):
+    def getCollectionStats(self):
         return self.collection().stats().report()
 
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -298,6 +298,11 @@ class AnkiConnect:
         return self.database().scalar('select count() from revlog where id > ?', (self.scheduler().dayCutoff - 86400) * 1000)
 
 
+    @util.api()
+    def collectionStats(self):
+        return self.collection().stats().report()
+
+
     #
     # Decks
     #

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -30,10 +30,6 @@ class TestMisc(unittest.TestCase):
             self.assertIsNone(result['error'])
             self.assertEqual(result['result'], 6)
 
-        # getNumCardsReviewedToday
-        result = util.invoke('getNumCardsReviewedToday')
-        self.assertIsInstance(result, int)
-
         # exportPackage
         fd, newname = tempfile.mkstemp(prefix='testexport', suffix='.apkg')
         os.close(fd)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -12,6 +12,10 @@ class TestMisc(unittest.TestCase):
         result = util.invoke('getNumCardsReviewedToday')
         self.assertIsInstance(result, int)
 
+        # collectionStats
+        result = util.invoke('collectionStats')
+        self.assertIsInstance(result, str)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+import tempfile
+import unittest
+import util
+
+
+class TestMisc(unittest.TestCase):
+    def runTest(self):
+        # getNumCardsReviewedToday
+        result = util.invoke('getNumCardsReviewedToday')
+        self.assertIsInstance(result, int)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,7 +13,7 @@ class TestMisc(unittest.TestCase):
         self.assertIsInstance(result, int)
 
         # collectionStats
-        result = util.invoke('collectionStats')
+        result = util.invoke('getCollectionStats')
         self.assertIsInstance(result, str)
 
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,7 +13,7 @@ class TestMisc(unittest.TestCase):
         self.assertIsInstance(result, int)
 
         # collectionStats
-        result = util.invoke('getCollectionStats')
+        result = util.invoke('getCollectionStatsHTML')
         self.assertIsInstance(result, str)
 
 


### PR DESCRIPTION
Return the collection statistics. Users may then parse that report for all the details they want about cards reviewed and times and whatnot instead of asking for an end point for each one.

It's unfortunate that Anki wraps the HTML presentation of the report and the queries to fetch the data into a single method, but I think it's preferable to let the users worry about running the result through BeautifulSoup or something instead of trying to maintain the queries to get the data out in a more consumable format.