### PR TITLE
collection stats - whole collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,10 @@ guarantee that your application continues to function properly in the future.
     ```json
     {
         "action": "getCollectionStatsHTML",
-        "version": 6
+        "version": 6,
+        "params": {
+            "wholeCollection": true
+        }
     }
     ```
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -299,8 +299,10 @@ class AnkiConnect:
 
 
     @util.api()
-    def getCollectionStatsHTML(self):
-        return self.collection().stats().report()
+    def getCollectionStatsHTML(self, wholeCollection=True):
+        stats = self.collection().stats()
+        stats.wholeCollection = wholeCollection
+        return stats.report()
 
 
     #


### PR DESCRIPTION
By default, the collection stats report retrieves only stats for the most recently viewed deck. Add a parameter to fetch stats for the whole collection.