### PR TITLE
Do not strip() during dupe check

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -236,7 +236,7 @@ class AnkiConnect:
 
         # dupeOrEmpty returns if a note is a global duplicate
         # the rest of the function checks to see if the note is a duplicate in the deck
-        val = note.fields[0].strip()
+        val = note.fields[0]
         did = deck['id']
         csum = anki.utils.fieldChecksum(val)
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import unittest
+import util
+
+
+class TestNotes(unittest.TestCase):
+    def setUp(self):
+        util.invoke('createDeck', deck='test')
+
+
+    def tearDown(self):
+        util.invoke('deleteDecks', decks=['test'], cardsToo=True)
+
+
+    def test_bug164(self):
+        note = {'deckName': 'test', 'modelName': 'Basic', 'fields': {'Front': ' Whitespace\n', 'Back': ''}, 'options': { 'allowDuplicate': False, 'duplicateScope': 'deck'}}
+        util.invoke('addNote', note=note)
+        self.assertRaises(Exception, lambda: util.invoke('addNote', note=note))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix #164 

The deck-level duplicate check was stripping whitespace before comparing the value. Anki does not do that. Anki only checks if the field would be empty if the whitespace were to be stripped; duplicate comparison is done with whitespace in place.