### PR TITLE
Don't call note.dupeOrEmpty when mode is 'deck'

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -240,16 +240,17 @@ class AnkiConnect:
 
     def isNoteDuplicateOrEmptyInScope(self, note, deck, collection, duplicateScope, duplicateScopeDeckName, duplicateScopeCheckChildren):
         "1 if first is empty; 2 if first is a duplicate, False otherwise."
-        result = note.dupeOrEmpty()
-        if result != 2 or duplicateScope != 'deck':
-            return result
+        if duplicateScope != 'deck':
+            return note.dupeOrEmpty()
 
         # dupeOrEmpty returns if a note is a global duplicate
         # the rest of the function checks to see if the note is a duplicate in the deck
         val = note.fields[0]
-        did = deck['id']
+        if not val.strip():
+            return 1
         csum = anki.utils.fieldChecksum(val)
 
+        did = deck['id']
         if duplicateScopeDeckName is not None:
             deck2 = collection.decks.byName(duplicateScopeDeckName)
             if deck2 is None:

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -233,15 +233,18 @@ class AnkiConnect:
             raise Exception('cannot create note because it is a duplicate')
           else:
             return ankiNote
-        elif duplicateOrEmpty == False:
+        elif duplicateOrEmpty == 0:
             return ankiNote
         else:
             raise Exception('cannot create note for unknown reason')
 
     def isNoteDuplicateOrEmptyInScope(self, note, deck, collection, duplicateScope, duplicateScopeDeckName, duplicateScopeCheckChildren):
-        "1 if first is empty; 2 if first is a duplicate, False otherwise."
+        "1 if first is empty; 2 if first is a duplicate, 0 otherwise."
         if duplicateScope != 'deck':
-            return note.dupeOrEmpty()
+            result = note.dupeOrEmpty()
+            if result == False:
+                return 0
+            return result
 
         # dupeOrEmpty returns if a note is a global duplicate
         # the rest of the function checks to see if the note is a duplicate in the deck
@@ -255,7 +258,7 @@ class AnkiConnect:
             deck2 = collection.decks.byName(duplicateScopeDeckName)
             if deck2 is None:
                 # Invalid deck, so cannot be duplicate
-                return False
+                return 0
             did = deck2['id']
 
         dids = {}
@@ -277,7 +280,7 @@ class AnkiConnect:
             ):
                 if cardDeckId in dids:
                     return 2
-        return False
+        return 0
 
 
     #

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -262,11 +262,10 @@ class AnkiConnect:
             did = deck2['id']
 
         dids = {}
+        dids[did] = True
         if duplicateScopeCheckChildren:
             for kv in collection.decks.children(did):
                 dids[kv[1]] = True
-        else:
-            dids[did] = True
 
         for noteId in note.col.db.list(
             "select id from notes where csum = ? and id != ? and mid = ?",


### PR DESCRIPTION
Remove some repeated duplicate checking when `duplicateScope == 'deck'`, which should slightly improve performance in the worst case.

Should also fix an issue where newer versions of the Anki source code changed the return value of `note.dupeOrEmpty` from `False` to `0`. Not sure if/when that change was released in a build.

Old `note.dupeOrEmpty` implementation:
https://github.com/ankitects/anki/blob/c8d13209cd2012092ae630d69b4c6ce2ad0da964~1/pylib/anki/notes.py#L142-L157

New `note.dupeOrEmpty` implementation:
https://github.com/ankitects/anki/blob/a834df60ce77fede0f3a325d1460627859d2086e/pylib/anki/notes.py#L146-L148

_Also_ fixes an issue from #203 where the main deck ID wasn't included in the `duplicateScopeCheckChildren` dict.

Related: https://github.com/FooSoft/yomichan/issues/993, https://github.com/FooSoft/yomichan/issues/992