### PR TITLE
Fix storeMediaFile never working

### DIFF
--- a/actions/media.md
+++ b/actions/media.md
@@ -37,7 +37,7 @@
         "version": 6,
         "params": {
             "filename": "_hello.txt",
-            "file": "/path/to/file"
+            "path": "/path/to/file"
         }
     }
     ```

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -475,7 +475,7 @@ class AnkiConnect:
         if data:
             self.deleteMediaFile(filename)
             self.media().writeData(filename, base64.b64decode(data))
-        elif file:
+        elif path:
             self.deleteMediaFile(filename)
             with open(path, 'rb') as f:
                 data = f.read()


### PR DESCRIPTION
Currently when you execute storeMediaFile like this:
```
curl localhost:8765 -X POST -d '{
    "action": "storeMediaFile",
    "version": 6,
    "params": {
        "filename": "hello.webp",
        "file": "/path/to/file"
    }
}'
```
It returns
`{"result": null, "error": "storeMediaFile() got an unexpected keyword argument 'file'"}%`
And if you execute it like this:
```
curl localhost:8765 -X POST -d '{
    "action": "storeMediaFile",
    "version": 6,
    "params": {
        "filename": "hello.webp",
        "path": "/path/to/file"
    }
}'
```
It returns
`{"result": null, "error": "name 'file' is not defined"}%`

This pull request should fix both situations and allow the user to use `path` to store local files.