### PR TITLE
Add links to query syntax documentation (#211)

### DIFF
--- a/actions/graphical.md
+++ b/actions/graphical.md
@@ -3,7 +3,7 @@
 *   **guiBrowse**
 
     Invokes the *Card Browser* dialog and searches for a given query. Returns an array of identifiers of the cards that
-    were found.
+    were found. Query syntax is [documented here](https://docs.ankiweb.net/#/searching).
 
     *Sample request*:
     ```json

--- a/actions/notes.md
+++ b/actions/notes.md
@@ -355,7 +355,7 @@
 
 *   **findNotes**
 
-    Returns an array of note IDs for a given query. Same query syntax as `guiBrowse`.
+    Returns an array of note IDs for a given query. Query syntax is [documented here](https://docs.ankiweb.net/#/searching).
 
     *Sample request*:
     ```json


### PR DESCRIPTION
It wasn't obvious that the query syntax is Anki's own, so add links to the documentation to help people down stream.