### PR TITLE
Fix bug in loadProfile method

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -304,7 +304,17 @@ class AnkiConnect:
             cur_profile = self.window().pm.name
             if cur_profile != name:
                 self.window().unloadProfileAndShowProfileManager()
-                self.loadProfile(name)
+
+                def waiter():
+                    # This function waits until main window is closed
+                    # It's needed cause sync can take quite some time
+                    # And if we call loadProfile until sync is ended things will go wrong
+                    if self.window().isVisible():
+                        QTimer.singleShot(1000, waiter)
+                    else:
+                        self.loadProfile(name)
+
+                waiter()
         else:
             self.window().pm.load(name)
             self.window().loadProfile()


### PR DESCRIPTION
When sync is enabled in profile, `loadProfile` fails. It happens because main window is still active during sync. The `loadProfile` method recursively calls itself over and over and tries to logout from profile each time (calling method                   `self.window().unloadProfileAndShowProfileManager()`). These actions overload Anki app.

My solution is to use a timer with an interval of 1 second to check if the main window is still active.

![bug_loadProfile](https://user-images.githubusercontent.com/49400499/107145745-ad43c080-6954-11eb-89a6-3ecbc4b28f04.gif)