### PR TITLE
Add "forgetCards" and "relearnCards"

### DIFF
--- a/actions/cards.md
+++ b/actions/cards.md
@@ -306,3 +306,49 @@
         "error": null
     }
     ```
+
+*   **forgetCards**
+
+    Forget cards, making the cards new again.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "forgetCards",
+        "version": 6,
+        "params": {
+            "cards": [1498938915662, 1502098034048]
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": null,
+        "error": null
+    }
+    ```
+
+*   **relearnCards**
+
+    Make cards be "relearning".
+
+    *Sample request*:
+    ```json
+    {
+        "action": "relearnCards",
+        "version": 6,
+        "params": {
+            "cards": [1498938915662, 1502098034048]
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": null,
+        "error": null
+    }
+    ```

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1006,6 +1006,22 @@ class AnkiConnect:
 
 
     @util.api()
+    def forgetCards(self, cards):
+        self.startEditing()
+        scids = anki.utils.ids2str(cards)
+        self.collection().db.execute('update cards set type=0, queue=0, left=0, ivl=0, due=0, odue=0, factor=0 where id in ' + scids)
+        self.stopEditing()
+
+
+    @util.api()
+    def relearnCards(self, cards):
+        self.startEditing()
+        scids = anki.utils.ids2str(cards)
+        self.collection().db.execute('update cards set type=3, queue=1 where id in ' + scids)
+        self.stopEditing()
+            
+
+    @util.api()
     def cardReviews(self, deck, startID):
         return self.database().all(
             'select id, cid, usn, ease, ivl, lastIvl, factor, time, type from revlog ''where id>? and cid in (select id from cards where did=?)',

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -74,6 +74,11 @@ class TestCards(unittest.TestCase):
         for i, cardInfo in enumerate(cardsInfo):
             self.assertEqual(cardInfo['cardId'], cardIds[i])
 
+        # forgetCards
+        util.invoke('forgetCards', cards=cardIds)
+
+        # relearnCards
+        util.invoke('relearnCards', cards=cardIds)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Use case of the new features
Sometimes there are some words I don't understand and after trying adding them to the deck,
I found out that they were already in the deck and I had studied them.
In the case, I want to study them again ASAP, so resetting the cards or making them "relearning" is convenient.

## About test codes
I tried to write the unit test, but there is no easy way to change the card's state.
If there is some method to change the card to "review", it'll be useful.
(Codes in `tests/test_cards.py` is only creating "new" cards)
Do you have any ideas?
Thank you