### PR TITLE
Fixed bug with skipHash causing media not to be added to notes

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -502,7 +502,7 @@ class AnkiConnect:
             skip = False
         else:
             m = hashlib.md5()
-            m.update(data)
+            m.update(mediaData)
             skip = skipHash == m.hexdigest()
 
         if skip:


### PR DESCRIPTION
When `skipHash` is used with an action like `addNote`, hashlib would throw `object supporting the buffer API required`.
This happened because the `data` variable was accidentally being used to calculate hashes instead of `mediaData`.