### PR TITLE
Use proper variable when computing skipHash

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -502,7 +502,7 @@ class AnkiConnect:
             skip = False
         else:
             m = hashlib.md5()
-            m.update(data)
+            m.update(mediaData)
             skip = skipHash == m.hexdigest()
 
         if skip:


### PR DESCRIPTION
If data is not passed but a URL is, the skipHash check will still use
the data variable instead of the one containing actual data (mediaData).

This fixes that issue.