### PR TITLE
Compare field names in a case-insensitive manner

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -210,8 +210,10 @@ class AnkiConnect:
             ankiNote.tags = note['tags']
 
         for name, value in note['fields'].items():
-            if name in ankiNote:
-                ankiNote[name] = value
+            for ankiName in ankiNote.keys():
+                if name.lower() == ankiName.lower():
+                    ankiNote[ankiName] = value
+                    break
 
         allowDuplicate = False
         duplicateScope = None


### PR DESCRIPTION
Field names should be compared in a case-insensitive manner, or if we were pedantic, with full case folding, but even Anki doesn't bother doing that in all cases (except maybe when creating fields), so lowercasing should be fine.
