### PR TITLE
Update createModel method to support Cloze models

### DIFF
--- a/actions/models.md
+++ b/actions/models.md
@@ -99,7 +99,9 @@
 *   **createModel**
 
     Creates a new model to be used in Anki. User must provide the `modelName`, `inOrderFields` and `cardTemplates` to be
-    used in the model. Optionally the `Name` field can be provided for each entry of `cardTemplates`. By default the
+    used in the model. There are optinal fields `css` and `isCloze`. If not specified, `css` will use the default Anki css and `isCloze` will be equal to `False`. If `isCloze` is `True` then model will be created as Cloze.
+
+    Optionally the `Name` field can be provided for each entry of `cardTemplates`. By default the
     card names will be `Card 1`, `Card 2`, and so on.
 
     *Sample request*
@@ -111,6 +113,7 @@
             "modelName": "newModelName",
             "inOrderFields": ["Field1", "Field2", "Field3"],
             "css": "Optional CSS with default to builtin css",
+            "isCloze": False,
             "cardTemplates": [
                 {
                     "Name": "My Card 1",

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -34,6 +34,7 @@ import anki.exporting
 import anki.storage
 import aqt
 from anki.cards import Card
+from anki.consts import MODEL_CLOZE
 
 from anki.exporting import AnkiPackageExporter
 from anki.importing import AnkiPackageImporter
@@ -821,7 +822,7 @@ class AnkiConnect:
 
 
     @util.api()
-    def createModel(self, modelName, inOrderFields, cardTemplates, css = None):
+    def createModel(self, modelName, inOrderFields, cardTemplates, css = None, isCloze = False):
         # https://github.com/dae/anki/blob/b06b70f7214fb1f2ce33ba06d2b095384b81f874/anki/stdmodels.py
         if len(inOrderFields) == 0:
             raise Exception('Must provide at least one field for inOrderFields')
@@ -835,6 +836,8 @@ class AnkiConnect:
 
         # Generate new Note
         m = mm.new(modelName)
+        if isCloze:
+            m['type'] = MODEL_CLOZE
 
         # Create fields and add them to Note
         for field in inOrderFields:


### PR DESCRIPTION
I've updated the `createModel` method so that it can be used to create Cloze note types. 