### PR TITLE
Fix vulnerability

### DIFF
--- a/plugin/config.json
+++ b/plugin/config.json
@@ -3,6 +3,5 @@
     "apiLogPath": null,
     "webBindAddress": "127.0.0.1",
     "webBindPort": 8765,
-    "webCorsOrigin": "http://localhost",
     "webCorsOriginList": ["http://localhost"]
 }

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -74,7 +74,7 @@ def setting(key):
         'webBacklog': 5,
         'webBindAddress': os.getenv('ANKICONNECT_BIND_ADDRESS', '127.0.0.1'),
         'webBindPort': 8765,
-        'webCorsOrigin': os.getenv('ANKICONNECT_CORS_ORIGIN', 'http://localhost'),
+        'webCorsOrigin': os.getenv('ANKICONNECT_CORS_ORIGIN', None),
         'webCorsOriginList': ['http://localhost'],
         'webTimeout': 10000,
     }

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -173,11 +173,12 @@ class WebServer:
 
         corsOrigin = 'http://localhost'
         allowAllCors = '*' in webCorsOriginList  # allow CORS for all domains
-        if len(webCorsOriginList) == 1 and not allowAllCors:
-            corsOrigin = webCorsOriginList[0]
+        
+        if allowAllCors :
+            corsOrigin = '*'
         elif b'origin' in req.headers:
             originStr = req.headers[b'origin'].decode()
-            if originStr in webCorsOriginList or allowAllCors:
+            if originStr in webCorsOriginList :
                 corsOrigin = originStr
 
         headers = [

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -154,14 +154,6 @@ class WebServer:
 
 
     def handlerWrapper(self, req):
-        if len(req.body) == 0:
-            body = 'AnkiConnect v.{}'.format(util.setting('apiVersion')).encode('utf-8')
-        else:
-            try:
-                params = json.loads(req.body.decode('utf-8'))
-                body = json.dumps(self.handler(params)).encode('utf-8')
-            except ValueError:
-                body = json.dumps(None).encode('utf-8')
 
         # handle multiple cors origins by checking the 'origin'-header against the allowed origin list from the config
         webCorsOriginList = util.setting('webCorsOriginList')
@@ -171,25 +163,47 @@ class WebServer:
         if webCorsOrigin:
             webCorsOriginList.append(webCorsOrigin)
 
+        allowed = False
         corsOrigin = 'http://localhost'
         allowAllCors = '*' in webCorsOriginList  # allow CORS for all domains
         
-        if allowAllCors :
+        if allowAllCors:
             corsOrigin = '*'
+            allowed = True
         elif b'origin' in req.headers:
             originStr = req.headers[b'origin'].decode()
             if originStr in webCorsOriginList :
                 corsOrigin = originStr
-
-        headers = [
-            ['HTTP/1.1 200 OK', None],
-            ['Content-Type', 'text/json'],
-            ['Access-Control-Allow-Origin', corsOrigin],
-            ['Access-Control-Allow-Headers', '*'],
-            ['Content-Length', str(len(body))]
-        ]
+                allowed = True
+        else:
+            allowed = True
 
         resp = bytes()
+
+        if allowed :
+            if len(req.body) == 0:
+                body = 'AnkiConnect v.{}'.format(util.setting('apiVersion')).encode('utf-8')
+            else:
+                try:
+                    params = json.loads(req.body.decode('utf-8'))
+                    body = json.dumps(self.handler(params)).encode('utf-8')
+                except ValueError:
+                    body = json.dumps(None).encode('utf-8')    
+                    
+            headers = [
+                ['HTTP/1.1 200 OK', None],
+                ['Content-Type', 'text/json'],
+                ['Access-Control-Allow-Origin', corsOrigin],
+                ['Access-Control-Allow-Headers', '*'],
+                ['Content-Length', str(len(body))]
+            ]
+        else :
+            headers = [
+                ['HTTP/1.1 403 Forbidden', None],
+                ['Access-Control-Allow-Origin', corsOrigin],
+                ['Access-Control-Allow-Headers', '*']
+            ]
+            body = ''.encode('utf-8');
 
         for key, value in headers:
             if value is None:

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -175,6 +175,12 @@ class WebServer:
             if originStr in webCorsOriginList :
                 corsOrigin = originStr
                 allowed = True
+            elif 'http://localhost' in webCorsOriginList and ( 
+            originStr == 'http://127.0.0.1' or originStr == 'https://127.0.0.1' or # allow 127.0.0.1 if localhost allowed
+            originStr.startswith('http://127.0.0.1:') or originStr.startswith('http://127.0.0.1:') or
+            originStr.startswith('chrome-extension://') or originStr.startswith('moz-extension://') ) : # allow chrome and firefox extension if localhost allowed
+                corsOrigin = originStr
+                allowed = True
         else:
             allowed = True
 


### PR DESCRIPTION
The current code to handle CORS is defective.

**It is currently possible to execute action even if origin is not allowed.** The browser will refuse to give the response to javascript (but it will still travel on the network), but the requested action will **still be executed**. So **it's possible to delete deck**, upload big or malicious file, etc.

This PR fix that by not executing the request action and returning a 403 error if the origin is not allowed.

Test effectued:
- [X] Api refuse the request if called from a not allowed origin (javascript)
- [X] Api handle the request if called from an allowed origin (javascript)
- [X] Api handle the request (python does not set origin)
- [X] Api handle the request if called from 127.0.0.1 and localhost allowed (javascript)
- [X] Api handle the request if called from google chrome or firefox extension and localhost allowed (javascript)

I added support for 127.0.0.1 and browser extension for compatibility reason, but for best security it shouldn't.

-----

This PR also include an improvement and simplification of the default code (https://github.com/FooSoft/anki-connect/commit/2a0010f0730d4e0ebe4af1609bd89fa378e0d518):
→ if `*` is in the list of allowed origin, set `Access-Control-Allow-Origin` to `*` even if the origin of the request is also in the list
→ if origin is not set in the request, return `http://localhost` even if there is only one element in the allowed origin list
The code was strange but I am not an expert so maybe there was a reason to these cases. Feel free to revert this commit.