### PR TITLE
Add requestPermission API method

### DIFF
--- a/actions/miscellaneous.md
+++ b/actions/miscellaneous.md
@@ -44,10 +44,6 @@
 
 Gets the version of the API exposed by this plugin. Currently versions `1` through `6` are defined.
 
-This should be the second call you make to make sure that your application and AnkiConnect are able to communicate
-properly with each other. New versions of AnkiConnect are backwards compatible; as long as you are using actions
-which are available in the reported AnkiConnect version or earlier, everything should work fine.
-
 *Sample request*:
 ```json
 {

--- a/actions/miscellaneous.md
+++ b/actions/miscellaneous.md
@@ -1,8 +1,12 @@
 # Miscellaneous Actions
 
-*   **version**
+*   **requestPermission**
 
-    Gets the version of the API exposed by this plugin. Currently versions `1` through `6` are defined.
+    Request permission to use the API exposed by this plugin. Only request coming from origin listed in the
+    `webCorsOriginList` option are allowed to use the Api. Calling this method will display a popup asking the user
+    if he want to allow your origin to use the Api. This is the only method that can be called even if the origin of
+    the request isn't in the `webCorsOriginList` list. It also doesn't require the api key. Calling this method will
+    not display the popup if the origin is already trusted.
 
     This should be the first call you make to make sure that your application and AnkiConnect are able to communicate
     properly with each other. New versions of AnkiConnect are backwards compatible; as long as you are using actions
@@ -11,18 +15,54 @@
     *Sample request*:
     ```json
     {
-        "action": "version",
+        "action": "requestPermission",
         "version": 6
     }
     ```
 
-    *Sample result*:
+    *Samples results*:
     ```json
     {
-        "result": 6,
+        "result": {
+            "permission": "granted",
+            "requireApiKey": false,
+            "version": 6
+        },
         "error": null
     }
     ```
+    ```json
+    {
+        "result": {
+            "permission": "denied"
+        },
+        "error": null
+    }
+    ```
+
+*   **version**
+
+Gets the version of the API exposed by this plugin. Currently versions `1` through `6` are defined.
+
+This should be the second call you make to make sure that your application and AnkiConnect are able to communicate
+properly with each other. New versions of AnkiConnect are backwards compatible; as long as you are using actions
+which are available in the reported AnkiConnect version or earlier, everything should work fine.
+
+*Sample request*:
+```json
+{
+    "action": "version",
+    "version": 6
+}
+```
+
+*Sample result*:
+```json
+{
+    "result": 6,
+    "error": null
+}
+```
 
 *   **sync**
 

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -3,5 +3,6 @@
     "apiLogPath": null,
     "webBindAddress": "127.0.0.1",
     "webBindPort": 8765,
-    "webCorsOriginList": ["http://localhost"]
+    "webCorsOriginList": ["http://localhost"],
+    "ignoreOriginList": []
 }

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -76,6 +76,7 @@ def setting(key):
         'webBindPort': 8765,
         'webCorsOrigin': os.getenv('ANKICONNECT_CORS_ORIGIN', None),
         'webCorsOriginList': ['http://localhost'],
+        'ignoreOriginList': [],
         'webTimeout': 10000,
     }
 


### PR DESCRIPTION
This allow website to request permission to use the Api by displaying a popup to the user.

![image](https://user-images.githubusercontent.com/53106394/117443932-14174c80-af39-11eb-8378-b7a98e04fffa.png)

- [x] Calling the method from an already trusted origin work
- [x] Calling the method from an untrusted origin work
- [x] Calling the method from an ignored origin doesn't display the popup
- [x] Calling an other api from an already trusted origin work  

Fix #254