### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,7 +966,7 @@ corresponding to when the API was available for use.
 *   **guiBrowse**
 
     Invokes the *Card Browser* dialog and searches for a given query. Returns an array of identifiers of the cards that
-    were found. Query syntax is [documented here](https://docs.ankiweb.net/#/searching).
+    were found. Query syntax is [documented here](https://docs.ankiweb.net/searching.html).
 
     *Sample request*:
     ```json
@@ -2337,7 +2337,7 @@ corresponding to when the API was available for use.
 
 *   **findNotes**
 
-    Returns an array of note IDs for a given query. Query syntax is [documented here](https://docs.ankiweb.net/#/searching).
+    Returns an array of note IDs for a given query. Query syntax is [documented here](https://docs.ankiweb.net/searching.html).
 
     *Sample request*:
     ```json


### PR DESCRIPTION
The searching documentation seems to have moved from `https://docs.ankiweb.net/#/searching` to `https://docs.ankiweb.net/searching.html`.