### PR TITLE
guiBrowse: Fixes MockModel error on new Anki versions

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1348,7 +1348,7 @@ class AnkiConnect:
             else:
                 browser.onSearchActivated()
 
-        return list(map(int, browser.model.cards))
+        return self.findCards(query)
 
 
     @util.api()


### PR DESCRIPTION
Anki deprecated access to the model from the API and the new MockModel
contained no attribute 'cards' leading to an error message being thrown
instead of card ids being returned. This change uses findCards to find
card ids instead of the model so no error is thrown while keeping
guiBrowse functionally equivalent to the previous version.
Fixes #277.