### PR TITLE
Clean up curl example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ included below as reference.
 #### Curl
 
 ```bash
-curl localhost:8765 -X POST -d "{\"action\": \"deckNames\", \"version\": 6}"
+curl localhost:8765 -X POST -d '{"action": "deckNames", "version": 6}'
 ```
 
 #### Python


### PR DESCRIPTION
Hi and thanks for the great piece of software!

`curl` seems to be the simplest way to create a dummy card & get a noteId from Anki on a Linux system (please, do ask), but the current docs sadly don't provide a copy-paste-able example for that. Would you like one?

This PR just gets rid of the escapes, but it could be made even more readable by some newlines - which work just fine - or those could be saved for the other examples.

```
$ curl localhost:8765 -X POST -d '
> {
>   "action": "deckNames",
>   "version": 6
> }'
{"result": ["Default", ...], "error": null}$ 
```