### PR TITLE
Add guiSelectedNotes action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,27 @@ corresponding to when the API was available for use.
     }
     ```
 
+*   **guiSelectedNotes**
+
+    Finds the open instance of the *Card Browser* dialog and returns an array of identifiers of the notes that are
+    selected. Returns an empty list if the browser is not open.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "guiSelectedNotes",
+        "version": 6
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": [1494723142483, 1494703460437, 1494703479525],
+        "error": null
+    }
+    ```
+
 *   **guiAddCards**
 
     Invokes the *Add Cards* dialog, presets the note using the given deck and model, with the provided field values and tags.

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1354,6 +1354,12 @@ class AnkiConnect:
 
         return self.findCards(query)
 
+    @util.api()
+    def guiSelectedNotes(self):
+        (creator, instance) = aqt.dialogs._dialogs['Browser']
+        if instance is None:
+            return []
+        return instance.selectedNotes()
 
     @util.api()
     def guiAddCards(self, note=None):

--- a/tests/test_graphical.py
+++ b/tests/test_graphical.py
@@ -9,6 +9,9 @@ class TestGui(unittest.TestCase):
         # guiBrowse
         util.invoke('guiBrowse', query='deck:Default')
 
+        # guiSelectedNotes
+        util.invoke('guiSelectedNotes')
+
         # guiAddCards
         util.invoke('guiAddCards')
 


### PR DESCRIPTION
This pull request introduces an API action for fetching the notes that are currently selected in the browser.

If the browser is open it returns the identifiers of the selected cards, otherwise it returns an empty list.

My example use case is automating edits to cards. Instead of copying and pasting a field from the card I want the script to detect the card that I'm looking at in the browser.

I have tested the change manually.

Thank you for developing such a useful addon.