### PR TITLE
Allow passing deleteExisting in addNote

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -709,7 +709,8 @@ class AnkiConnect:
                                                         data=media.get('data'),
                                                         path=media.get('path'),
                                                         url=media.get('url'),
-                                                        skipHash=media.get('skipHash'))
+                                                        skipHash=media.get('skipHash'),
+                                                        deleteExisting=media.get('deleteExisting'))
 
                     if mediaFilename is not None:
                         for field in media['fields']:


### PR DESCRIPTION
I just noticed I forgot to make the `deleteExisting` option I added in #257 usable in addNote.