### PR TITLE
Update requestPermission documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1503,11 +1503,12 @@ corresponding to when the API was available for use.
 
 *   **requestPermission**
 
-    Request permission to use the API exposed by this plugin. Only request coming from origin listed in the
-    `webCorsOriginList` option are allowed to use the Api. Calling this method will display a popup asking the user
-    if he want to allow your origin to use the Api. This is the only method that can be called even if the origin of
-    the request isn't in the `webCorsOriginList` list. It also doesn't require the api key. Calling this method will
-    not display the popup if the origin is already trusted.
+    Requests permission to use the API exposed by this plugin. This method does not require the API key, and is the
+    only one that accepts requests from any origin; the other methods only accept requests from trusted origins,
+    which are listed under `webCorsOriginList` in the plugin config.
+    
+    Calling this method from an untrusted origin will display a popup in Anki asking the user whether they want to
+    allow your origin to use the API; calls from trusted origins will return the result without displaying the popup.
 
     This should be the first call you make to make sure that your application and Anki-Connect are able to communicate
     properly with each other. New versions of Anki-Connect are backwards compatible; as long as you are using actions


### PR DESCRIPTION
Draft.

Should probs lead with "This should be the first call you make", but if that's true, then why is it burried in the misc section, not mentioned anywhere else, and introduced without bumping the API version to 7?