### PR TITLE
Fix tests and some of the code to work with Anki 2.1.50

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pyqt5-dev-tools xvfb
 
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
 
       - name: Install tox
         run: pip install tox

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 AnkiConnect.zip
 meta.json
 .idea/
+.tox/

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -27,6 +27,7 @@ import inspect
 import json
 import os
 import os.path
+import platform
 import re
 import time
 import unicodedata
@@ -1619,6 +1620,9 @@ class AnkiConnect:
 # when run inside Anki, `__name__` would be either numeric,
 # or, if installed via `link.sh`, `AnkiConnectDev`
 if __name__ != "plugin":
+    if platform.system() == "Windows" and anki_version == (2, 1, 50):
+        util.patch_anki_2_1_50_having_null_stdout_on_windows()
+
     Edit.register_with_anki()
 
     ac = AnkiConnect()

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1425,9 +1425,7 @@ class AnkiConnect:
                 if savedMid:
                     deck['mid'] = savedMid
 
-                addCards.editor.note = ankiNote
-                addCards.editor.loadNote()
-                addCards.editor.updateTags()
+                addCards.editor.set_note(ankiNote)
 
                 addCards.activateWindow()
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -13,6 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import aqt
+
+anki_version = tuple(int(segment) for segment in aqt.appVersion.split("."))
+
+if anki_version < (2, 1, 45):
+    raise Exception("Minimum Anki version supported: 2.1.45")
+
 import base64
 import glob
 import hashlib
@@ -27,21 +34,15 @@ import unicodedata
 import anki
 import anki.exporting
 import anki.storage
-import aqt
 from anki.cards import Card
 from anki.consts import MODEL_CLOZE
 from anki.exporting import AnkiPackageExporter
 from anki.importing import AnkiPackageImporter
 from anki.notes import Note
+from anki.errors import NotFoundError
 from aqt.qt import Qt, QTimer, QMessageBox, QCheckBox
 
 from .edit import Edit
-
-try:
-    from anki.rsbackend import NotFoundError
-except:
-    NotFoundError = Exception
-
 from . import web, util
 
 
@@ -50,8 +51,6 @@ from . import web, util
 #
 
 class AnkiConnect:
-    _anki21_version = int(aqt.appVersion.split('.')[-1])
-
     def __init__(self):
         self.log = None
         self.timer = None
@@ -78,11 +77,7 @@ class AnkiConnect:
             )
 
     def save_model(self, models, ankiModel):
-        if self._anki21_version < 45:
-            models.save(ankiModel, True)
-            models.flush()
-        else:
-            models.update_dict(ankiModel)
+        models.update_dict(ankiModel)
 
     def logEvent(self, name, data):
         if self.log is not None:
@@ -541,9 +536,8 @@ class AnkiConnect:
             # however, since 62c23c6816adf912776b9378c008a52bb50b2e8d (2.1.45)
             # passing cardsToo to `rem` (long deprecated) won't raise an error!
             # this is dangerous, so let's raise our own exception
-            if self._anki21_version >= 28:
-                raise Exception("Since Anki 2.1.28 it's not possible "
-                                "to delete decks without deleting cards as well")
+            raise Exception("Since Anki 2.1.28 it's not possible "
+                            "to delete decks without deleting cards as well")
         try:
             self.startEditing()
             decks = filter(lambda d: d in self.deckNames(), decks)

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -20,15 +20,9 @@ import inspect
 import json
 import os
 import os.path
-import random
 import re
-import string
 import time
 import unicodedata
-
-from PyQt5 import QtCore
-from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import QMessageBox, QCheckBox
 
 import anki
 import anki.exporting
@@ -36,10 +30,10 @@ import anki.storage
 import aqt
 from anki.cards import Card
 from anki.consts import MODEL_CLOZE
-
 from anki.exporting import AnkiPackageExporter
 from anki.importing import AnkiPackageImporter
 from anki.notes import Note
+from aqt.qt import Qt, QTimer, QMessageBox, QCheckBox
 
 from .edit import Edit
 
@@ -391,7 +385,7 @@ class AnkiConnect:
             msg.setStandardButtons(QMessageBox.Yes|QMessageBox.No)
             msg.setDefaultButton(QMessageBox.No)
             msg.setCheckBox(QCheckBox(text='Ignore further requests from "{}"'.format(origin), parent=msg))
-            msg.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
+            msg.setWindowFlags(Qt.WindowStaysOnTopHint)
             pressedButton = msg.exec_()
 
             if pressedButton == QMessageBox.Yes:

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -8,6 +8,8 @@ from anki.errors import NotFoundError
 from anki.consts import QUEUE_TYPE_SUSPENDED
 from anki.utils import ids2str
 
+from . import anki_version
+
 
 # Edit dialog. Like Edit Current, but:
 #   * has a Preview button to preview the cards for the note
@@ -24,8 +26,6 @@ from anki.utils import ids2str
 
 
 DOMAIN_PREFIX = "foosoft.ankiconnect."
-
-anki_version = tuple(int(segment) for segment in aqt.appVersion.split("."))
 
 
 def get_note_by_note_id(note_id):

--- a/plugin/edit.py
+++ b/plugin/edit.py
@@ -184,7 +184,7 @@ class Edit(aqt.editcurrent.EditCurrent):
     # upon a request to open the dialog via `aqt.dialogs.open()`,
     # the manager will call either the constructor or the `reopen` method
     def __init__(self, note):
-        QDialog.__init__(self, None, Qt.Window)
+        QDialog.__init__(self, None, Qt.WindowType.Window)
         aqt.mw.garbage_collect_on_dialog_finish(self)
         self.form = aqt.forms.editcurrent.Ui_Dialog()
         self.form.setupUi(self)

--- a/plugin/util.py
+++ b/plugin/util.py
@@ -14,6 +14,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 
 import anki
 import anki.sync
@@ -83,3 +84,10 @@ def setting(key):
         return aqt.mw.addonManager.getConfig(__name__).get(key, DEFAULT_CONFIG[key])
     except:
         raise Exception('setting {} not found'.format(key))
+
+
+# see https://github.com/FooSoft/anki-connect/issues/308
+# fixed in https://github.com/ankitects/anki/commit/0b2a226d
+def patch_anki_2_1_50_having_null_stdout_on_windows():
+    if sys.stdout is None:
+        sys.stdout = open(os.devnull, "w", encoding="utf8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from _pytest.monkeypatch import MonkeyPatch  # noqa
 from pytest_anki._launch import anki_running, temporary_user  # noqa
 from waitress import wasyncore
 
-from plugin import AnkiConnect
+from plugin import AnkiConnect, anki_version
 from plugin.edit import Edit
 from plugin.util import DEFAULT_CONFIG
 
@@ -85,7 +85,7 @@ def waitress_patched_to_prevent_it_from_dying():
 @contextmanager
 def anki_patched_to_prevent_backups():
     with MonkeyPatch().context() as monkey:
-        if ac._anki21_version < 50:
+        if anki_version < (2, 1, 50):
             monkey.setitem(aqt.profiles.profileConf, "numBackups", 0)
         else:
             monkey.setattr(anki.collection.Collection, "create_backup",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 import aqt.operations.note
 import pytest
 import anki.collection
-from PyQt5 import QtTest
 from _pytest.monkeypatch import MonkeyPatch  # noqa
 from pytest_anki._launch import anki_running, temporary_user  # noqa
 from waitress import wasyncore
@@ -14,6 +13,11 @@ from waitress import wasyncore
 from plugin import AnkiConnect
 from plugin.edit import Edit
 from plugin.util import DEFAULT_CONFIG
+
+try:
+    from PyQt6 import QtTest
+except ImportError:
+    from PyQt5 import QtTest
 
 
 ac = AnkiConnect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import aqt.operations.note
 import pytest
+import anki.collection
 from PyQt5 import QtTest
 from _pytest.monkeypatch import MonkeyPatch  # noqa
 from pytest_anki._launch import anki_running, temporary_user  # noqa
@@ -78,21 +79,32 @@ def waitress_patched_to_prevent_it_from_dying():
 
 
 @contextmanager
+def anki_patched_to_prevent_backups():
+    with MonkeyPatch().context() as monkey:
+        if ac._anki21_version < 50:
+            monkey.setitem(aqt.profiles.profileConf, "numBackups", 0)
+        else:
+            monkey.setattr(anki.collection.Collection, "create_backup",
+                           lambda *args, **kwargs: True)
+        yield
+
+
+@contextmanager
 def empty_anki_session_started():
     with waitress_patched_to_prevent_it_from_dying():
-        with anki_running(
-            qtbot=None,  # noqa
-            enable_web_debugging=False,
-            profile_name="test_user",
-        ) as session:
-            yield session
+        with anki_patched_to_prevent_backups():
+            with anki_running(
+                qtbot=None,  # noqa
+                enable_web_debugging=False,
+                profile_name="test_user",
+            ) as session:
+                yield session
 
 
 @contextmanager
 def profile_created_and_loaded(session):
     with temporary_user(session.base, "test_user", "en_US"):
         with session.profile_loaded():
-            aqt.mw.pm.profile["numBackups"] = 0     # don't try to do backups
             yield session
 
 

--- a/tests/test_decks.py
+++ b/tests/test_decks.py
@@ -30,10 +30,6 @@ def test_deleteDeck(setup):
     assert {*before} - {*after} == {"test_deck"}
 
 
-@pytest.mark.skipif(
-    condition=ac._anki21_version < 28,
-    reason=f"Not applicable to Anki < 2.1.28"
-)
 def test_deleteDeck_must_be_called_with_cardsToo_set_to_True_on_later_api(setup):
     with pytest.raises(Exception):
         ac.deleteDecks(decks=["test_deck"])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,7 @@
+import os
+
 import aqt
+import pytest
 
 from conftest import ac, anki_connect_config_loaded, \
     set_up_test_deck_and_test_model_and_two_notes, \
@@ -33,6 +36,19 @@ class TestProfiles:
 
 
 class TestExportImport:
+    # since Anki 2.1.50, exporting media for some wild reason
+    # will change the current working directory, which then gets removed.
+    # see `exporting.py`, ctrl-f `os.chdir(self.mediaDir)`
+    @pytest.fixture(autouse=True)
+    def current_working_directory_preserved(self):
+        cwd = os.getcwd()
+        yield
+
+        try:
+            os.getcwd()
+        except FileNotFoundError:
+            os.chdir(cwd)
+
     def test_exportPackage(self,  session_with_profile_loaded, setup):
         filename = session_with_profile_loaded.base + "/export.apkg"
         ac.exportPackage(deck="test_deck", path=filename)

--- a/tox.ini
+++ b/tox.ini
@@ -40,25 +40,26 @@
 #       LIBGL_ALWAYS_INDIRECT=1
 #       QTWEBENGINE_CHROMIUM_FLAGS="--disable-gpu"
 #       QT_DEBUG_PLUGINS=1
-#       ANKIDEV=true
+#       ANKIDEV=1
 
 [tox]
 minversion = 3.24
 skipsdist = true
 skip_install = true
-envlist = py38-anki{45,46,47,48,49},py39-anki50qt5
+envlist = py38-anki{45,46,47,48,49},py39-anki{50qt5,50qt6}
 
 [testenv]
 commands =
     xvfb-run python -m pytest {posargs}
 setenv =
     HOME={envdir}/home
+    anki50qt6: DISABLE_QT5_COMPAT=1
 allowlist_externals =
     xvfb-run
 deps =
     pytest==7.1.1
     pytest-forked==1.4.0
-    pytest-anki @ git+https://github.com/oakkitten/pytest-anki.git@97708344
+    pytest-anki @ git+https://github.com/oakkitten/pytest-anki.git@a0d27aa5
 
     anki45: anki==2.1.45
     anki45: aqt==2.1.45
@@ -77,3 +78,6 @@ deps =
 
     anki50qt5: anki==2.1.50
     anki50qt5: aqt[qt5]==2.1.50
+
+    anki50qt6: anki==2.1.50
+    anki50qt6: aqt[qt6]==2.1.50

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@
 minversion = 3.24
 skipsdist = true
 skip_install = true
-envlist = py38-anki{45,46,47,48,49}
+envlist = py38-anki{45,46,47,48,49},py39-anki50qt5
 
 [testenv]
 commands =
@@ -58,7 +58,7 @@ allowlist_externals =
 deps =
     pytest==7.1.1
     pytest-forked==1.4.0
-    pytest-anki @ git+https://github.com/oakkitten/pytest-anki.git@17d19043
+    pytest-anki @ git+https://github.com/oakkitten/pytest-anki.git@97708344
 
     anki45: anki==2.1.45
     anki45: aqt==2.1.45
@@ -74,3 +74,6 @@ deps =
 
     anki49: anki==2.1.49
     anki49: aqt==2.1.49
+
+    anki50qt5: anki==2.1.50
+    anki50qt5: aqt[qt5]==2.1.50

--- a/tox.ini
+++ b/tox.ini
@@ -50,11 +50,11 @@ envlist = py38-anki{45,46,47,48,49},py39-anki{50qt5,50qt6}
 
 [testenv]
 commands =
-    xvfb-run python -m pytest {posargs}
+    env HOME={envtmpdir}/home xvfb-run python -m pytest {posargs}
 setenv =
-    HOME={envdir}/home
     anki50qt6: DISABLE_QT5_COMPAT=1
 allowlist_externals =
+    env
     xvfb-run
 deps =
     pytest==7.1.1


### PR DESCRIPTION
In addition to the tests environments added in #306, this adds two environments for Anki 2.1.50, to test with Qt5 and Qt6. Also, I fixed the way buttons look in the Edit dialog on 2.1.50 and added some tests for the buttons themselves. Also included is a fix for #308.

Essentially, this makes the tests pass, and I can add and view cards via Yomichan on Windows without issues now. There might still be some issues in the untested areas maybe.

This draft is based on the current master, which includes the squashed #306. I would be _more_ than happy to rebase it on the original, unsquashed commits of #306. These were good commits, or so I want to believe 😔. (They say that you should never rewrite master, but I won't tell anyone if you don't.)

This PR is mostly OK but I'll give it a few days before marking as ready—just in case.