### PR TITLE
Add getDeckStats action

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,46 @@ corresponding to when the API was available for use.
     }
     ```
 
+*   **getDeckStats**
+
+    Gets statistics such as total cards and cards due for the given decks.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "getDeckStats",
+        "version": 6,
+        "params": {
+            "decks": ["Japanese::JLPT N5", "Easy Spanish"]
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": {
+            "1651445861967": {
+                "deck_id": 1651445861967,
+                "name": "Japanese::JLPT N5",
+                "new_count": 20,
+                "learn_count": 0,
+                "review_count": 0,
+                "total_in_deck": 1506
+            },
+            "1651445861960": {
+                "deck_id": 1651445861960,
+                "name": "Easy Spanish",
+                "new_count": 26,
+                "learn_count": 10,
+                "review_count": 5,
+                "total_in_deck": 852
+            }
+        },
+        "error": null
+    }
+    ```
+
 #### Graphical Actions
 
 *   **guiBrowse**

--- a/tests/test_decks.py
+++ b/tests/test_decks.py
@@ -67,3 +67,8 @@ def test_removedDeckConfigId_fails_with_invalid_id(session_with_profile_loaded):
     new_config_id = ac.cloneDeckConfigId(cloneFrom=1, name="test")
     assert ac.removeDeckConfigId(configId=new_config_id) is True
     assert ac.removeDeckConfigId(configId=new_config_id) is False
+
+
+def test_getDeckStats(session_with_profile_loaded):
+    result = ac.getDeckStats(decks=["Default"])
+    assert result["name"] == "Default"


### PR DESCRIPTION
This PR adds an action that allows the API to get statistics for given decks. This is useful for consumers that would like to know the number of cards already in a deck or the daily new cards or reviews remaining.