### PR TITLE
Produce a better error in case of malformed JSON

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -43,6 +43,7 @@ from anki.notes import Note
 from anki.errors import NotFoundError
 from aqt.qt import Qt, QTimer, QMessageBox, QCheckBox
 
+from .web import format_exception_reply, format_success_reply
 from .edit import Edit
 from . import web, util
 
@@ -99,7 +100,6 @@ class AnkiConnect:
         version = request.get('version', 4)
         params = request.get('params', {})
         key = request.get('key')
-        reply = {'result': None, 'error': None}
 
         try:
             if key != util.setting('apiKey') and name != 'requestPermission':
@@ -126,14 +126,12 @@ class AnkiConnect:
 
             if method is None:
                 raise Exception('unsupported action')
-            else:
-                reply['result'] = methodInst(**params)
 
-            if version <= 4:
-                reply = reply['result']
+            api_return_value = methodInst(**params)
+            reply = format_success_reply(version, api_return_value)
 
         except Exception as e:
-            reply['error'] = str(e)
+            reply = format_exception_reply(version, e)
 
         self.logEvent('reply', reply)
         return reply

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -14,6 +14,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import jsonschema
 import select
 import socket
 
@@ -177,7 +178,8 @@ class WebServer:
     
         try:
             params = json.loads(req.body.decode('utf-8'))
-        except ValueError as e:
+            jsonschema.validate(params, request_schema)
+        except (ValueError, jsonschema.ValidationError) as e:
             if allowed:
                 if len(req.body) == 0:
                     body = f"AnkiConnect v.{util.setting('apiVersion')}".encode()
@@ -286,3 +288,14 @@ def format_success_reply(api_version, result):
 
 def format_exception_reply(_api_version, exception):
     return {"result": None, "error": str(exception)}
+
+
+request_schema = {
+    "type": "object",
+    "properties": {
+        "action": {"type": "string", "minLength": 1},
+        "version": {"type": "integer"},
+        "params": {"type": "object"},
+    },
+    "required": ["action"],
+}

--- a/plugin/web.py
+++ b/plugin/web.py
@@ -175,27 +175,29 @@ class WebServer:
 
             return self.buildResponse(headers, body)
     
-        paramsError = False
-
         try:
             params = json.loads(req.body.decode('utf-8'))
-        except ValueError:
-            body = json.dumps(None).encode('utf-8')
-            paramsError = True
-
-        if allowed or not paramsError and params.get('action', '') == 'requestPermission':
-            if len(req.body) == 0:
-                body = 'AnkiConnect v.{}'.format(util.setting('apiVersion')).encode('utf-8')
+        except ValueError as e:
+            if allowed:
+                if len(req.body) == 0:
+                    body = f"AnkiConnect v.{util.setting('apiVersion')}".encode()
+                else:
+                    reply = format_exception_reply(util.setting('apiVersion'), e)
+                    body = json.dumps(reply).encode('utf-8')
+                headers = self.buildHeaders(corsOrigin, body)
+                return self.buildResponse(headers, body)
             else:
-                if params.get('action', '') == 'requestPermission':
-                    params['params'] = params.get('params', {})
-                    params['params']['allowed'] = allowed
-                    params['params']['origin'] = b'origin' in req.headers and req.headers[b'origin'].decode() or ''
-                    if not allowed :
-                        corsOrigin = params['params']['origin']
+                params = {}  # trigger the 403 response below
+
+        if allowed or params.get('action', '') == 'requestPermission':
+            if params.get('action', '') == 'requestPermission':
+                params['params'] = params.get('params', {})
+                params['params']['allowed'] = allowed
+                params['params']['origin'] = b'origin' in req.headers and req.headers[b'origin'].decode() or ''
+                if not allowed :
+                    corsOrigin = params['params']['origin']
                         
-                body = json.dumps(self.handler(params)).encode('utf-8')
-                    
+            body = json.dumps(self.handler(params)).encode('utf-8')
             headers = self.buildHeaders(corsOrigin, body)
         else :
             headers = [
@@ -273,3 +275,14 @@ class WebServer:
             client.close()
 
         self.clients = []
+
+
+def format_success_reply(api_version, result):
+    if api_version <= 4:
+        return result
+    else:
+        return {"result": result, "error": None}
+
+
+def format_exception_reply(_api_version, exception):
+    return {"result": None, "error": str(exception)}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,6 +169,24 @@ def test_failing_request_due_to_bad_json(external_anki):
     assert "in double quotes" in response["error"]
 
 
+def test_failing_request_due_to_json_root_not_being_an_object(external_anki):
+    response = json.loads(external_anki.send_bytes(b"1.2"))
+    assert response["result"] is None
+    assert "is not of type 'object'" in response["error"]
+
+
+def test_failing_request_due_to_json_missing_wanted_properties(external_anki):
+    response = json.loads(external_anki.send_bytes(b"{}"))
+    assert response["result"] is None
+    assert "'action' is a required property" in response["error"]
+
+
+def test_failing_request_due_to_json_properties_being_of_wrong_types(external_anki):
+    response = json.loads(external_anki.send_bytes(b'{"action": 1}'))
+    assert response["result"] is None
+    assert "1 is not of type 'string'" in response["error"]
+
+
 def test_403_in_case_of_disallowed_origin(external_anki):
     with pytest.raises(urllib.error.HTTPError, match="403"):  # good request/json
         json_bytes = json.dumps(Client.make_request("version")).encode("utf-8")


### PR DESCRIPTION
This solves the same issue that #317 solves, albeit slightly differently. I was hoping that the author would reopen the issue... There's a few differences;

* If origin is not allowed, 403 is returned in case of malformed JSON, and
* In case of JSON error, error string is returned to user.

I also noticed this bit: `params['params'] = params.get('params', {})`. It's a tad dangerous since this part of code can be run when not allowed, and `params` can be present but not be a dictionary. In this case the plugin would “crash”, and while this only amounts to showing a window with an error, it can be theoretically triggered by a malicious website, so I opted for verifying request schema. (Anki comes with `jsonschema` which is used to verify addon configurations.) This is not ideal, but I wanted to touch as little code as possible.

I added a few tests that test behavior around the change.

@nvlled Could you please look at this and tell if I did something stupid? 😬