### PR TITLE
apiReflect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1560,6 +1560,43 @@ corresponding to when the API was available for use.
     }
     ```
 
+
+*   **apiReflect**
+
+    Gets information about the AnkiConnect APIs available. The request supports the following params:
+
+    * `scopes` - An array of scopes to get reflection information about.
+      The only currently supported value is `"actions"`.
+    * `actions` - Either `null` or an array of API method names to check for.
+      If the value is `null`, the result will list all of the available API actions.
+      If the value is an array of strings, the result will only contain actions which were in this array.
+
+    The result will contain a list of which scopes were used and a value for each scope.
+    For example, the `"actions"` scope will contain a `"actions"` property which contains a list of supported action names.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "apiReflect",
+        "params": {
+            "scopes": ["actions", "invalidType"],
+            "actions": ["apiReflect", "invalidMethod"]
+        },
+        "version": 6
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": {
+            "scopes": ["actions"],
+            "actions": ["apiReflect"]
+        },
+        "error": null
+    }
+    ```
+
 *   **sync**
 
     Synchronizes the local Anki collections with AnkiWeb.

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1640,6 +1640,36 @@ class AnkiConnect:
 
         return False
 
+
+    @util.api()
+    def apiReflect(self, scopes=None, actions=None):
+        if not isinstance(scopes, list):
+            raise Exception('scopes has invalid value')
+        if not (actions is None or isinstance(actions, list)):
+            raise Exception('actions has invalid value')
+
+        cls = type(self)
+        scopes2 = []
+        result = {'scopes': scopes2}
+
+        if 'actions' in scopes:
+            if actions is None:
+                actions = dir(cls)
+
+            methodNames = []
+            for methodName in actions:
+                if not isinstance(methodName, str):
+                    pass
+                method = getattr(cls, methodName, None)
+                if method is not None and getattr(method, 'api', False):
+                    methodNames.append(methodName)
+
+            scopes2.append('actions')
+            result['actions'] = methodNames
+
+        return result
+
+
 #
 # Entry
 #

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -21,6 +21,17 @@ def test_reloadCollection(setup):
     ac.reloadCollection()
 
 
+def test_apiReflect(setup):
+    result = ac.apiReflect(
+        scopes=["actions", "invalidType"],
+        actions=["apiReflect", "invalidMethod"]
+    )
+    assert result == {
+        "scopes": ["actions"],
+        "actions": ["apiReflect"]
+    }
+
+
 class TestProfiles:
     def test_getProfiles(self, session_with_profile_loaded):
         result = ac.getProfiles()


### PR DESCRIPTION
This change adds an `apiReflect` action, which can be used to list the available APIs. This may be useful for feature detection, potentially in Yomichan.