### PR TITLE
Feat: add `interpret` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1753,6 +1753,29 @@ corresponding to when the API was available for use.
     }
     ```
 
+*   **interpret**
+
+    Executes arbitrary code in the plugin's namespace and returns the result or `null` if given a statement. If the result cannot be JSON-encoded, it is stringified.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "interpret",
+        "params": {
+            "code": "aqt",
+        },
+        "version": 6,
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": "<module 'aqt' (<oxidized_importer.OxidizedFinder object at 0x7f3aa5551be0>)>",
+        "error": null,
+    }
+    ```
+
 #### Model Actions
 
 *   **modelNames**

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -57,6 +57,7 @@ class AnkiConnect:
         self.log = None
         self.timer = None
         self.server = web.WebServer(self.handler)
+        self._namespace = globals()
 
     def initLogging(self):
         logPath = util.setting('apiLogPath')
@@ -481,6 +482,38 @@ class AnkiConnect:
         stats = self.collection().stats()
         stats.wholeCollection = wholeCollection
         return stats.report()
+
+    @util.api()
+    def interpret(self, code):
+        ns = self._namespace
+        result = False
+
+        try:
+            compile(code, "", "eval")
+            expr = True
+
+        except SyntaxError:
+            expr = False
+
+        try:
+            if expr:
+                result = eval(code, ns)
+
+            else:
+                exec(code, ns)
+                result = None
+
+        except Exception as e:
+            result = repr(e)
+
+        try:
+            import json
+            json.dumps(result)
+
+        except:
+            result = str(result)
+        return result
+
 
 
     #

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -75,3 +75,13 @@ class TestExportImport:
             assert "test_deck" not in ac.deckNames()
             ac.importPackage(path=filename)
             assert "test_deck" in ac.deckNames()
+
+
+def test_interpret():
+    fn_str = "def average_nums(*nums):\n    return sum(nums) / len(nums)"
+    ac.interpret(fn_str)
+    assert ac.interpret(
+        "'average_nums' in globals() and callable(average_nums)") is True
+    assert ac.interpret("average_nums(1, 2, 3)") == 2
+    ac.interpret("del average_nums")
+    return


### PR DESCRIPTION
This PR adds the `interpret` action, which allows code to be run in the context of the add-on. This allows consumers to perform arbitrary actions, without the need to define specific API points.