### PR TITLE
Added getReviewsOfCards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2759,18 +2759,21 @@ corresponding to when the API was available for use.
     }
     ```
 
-*   **getReviewsOfCard**
+*   **getReviewsOfCards**
 
-    Requests all card reviews for a specific card ID.
-    Returns a list of 9-tuples in the same format as `cardReviews`: `(reviewTime, cardID, usn, buttonPressed, newInterval, previousInterval, newFactor, reviewDuration, reviewType)`
+    Requests all card reviews for each card ID.
+    Returns a dictionary mapping the card ID to 9-tuples in the same format as `cardReviews`:
+    `(reviewTime, cardID, usn, buttonPressed, newInterval, previousInterval, newFactor, reviewDuration, reviewType)`
 
     *Sample request*:
     ```json
     {
-        "action": "getReviewsOfCard",
+        "action": "getReviewsOfCards",
         "version": 6,
         "params": {
-            "card": "1653613948202"
+            "cards": [
+                "1653613948202"
+            ]
         }
     }
     ```
@@ -2778,12 +2781,14 @@ corresponding to when the API was available for use.
     *Sample result*:
     ```json
     {
-        "result": [
-            [1654102387663, 1653613948202, 1780, 3, 8, 3, 2500, 25796, 1],
-            [1654798974478, 1653613948202, 1861, 3, 20, 8, 2500, 18134, 1],
-            [1656556319328, 1653613948202, 2075, 3, 53, 20, 2500, 20530, 1],
-            [1661107990069, 1653613948202, 2478, 3, 131, 53, 2500, 24247, 1]
-        ],
+        "result": {
+            "1653613948202": [
+                [1654102387663, 1653613948202, 1780, 3,   8,  3, 2500, 25796, 1],
+                [1654798974478, 1653613948202, 1861, 3,  20,  8, 2500, 18134, 1],
+                [1656556319328, 1653613948202, 2075, 3,  53, 20, 2500, 20530, 1],
+                [1661107990069, 1653613948202, 2478, 3, 131, 53, 2500, 24247, 1]
+            ]
+        },
         "error": null
     }
     ```

--- a/README.md
+++ b/README.md
@@ -2759,6 +2759,35 @@ corresponding to when the API was available for use.
     }
     ```
 
+*   **getReviewsOfCard**
+
+    Requests all card reviews for a specific card ID.
+    Returns a list of 9-tuples in the same format as `cardReviews`: `(reviewTime, cardID, usn, buttonPressed, newInterval, previousInterval, newFactor, reviewDuration, reviewType)`
+
+    *Sample request*:
+    ```json
+    {
+        "action": "getReviewsOfCard",
+        "version": 6,
+        "params": {
+            "card": "1653613948202"
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": [
+            [1654102387663, 1653613948202, 1780, 3, 8, 3, 2500, 25796, 1],
+            [1654798974478, 1653613948202, 1861, 3, 20, 8, 2500, 18134, 1],
+            [1656556319328, 1653613948202, 2075, 3, 53, 20, 2500, 20530, 1],
+            [1661107990069, 1653613948202, 2478, 3, 131, 53, 2500, 24247, 1]
+        ],
+        "error": null
+    }
+    ```
+
 *   **getLatestReviewID**
 
     Returns the unix time of the latest review for the given deck. 0 if no review has ever been made for the deck.

--- a/README.md
+++ b/README.md
@@ -2767,8 +2767,21 @@ corresponding to when the API was available for use.
 *   **getReviewsOfCards**
 
     Requests all card reviews for each card ID.
-    Returns a dictionary mapping the card ID to 9-tuples in the same format as `cardReviews`:
-    `(reviewTime, cardID, usn, buttonPressed, newInterval, previousInterval, newFactor, reviewDuration, reviewType)`
+    Returns a dictionary mapping each card ID to a list of dictionaries of the format:
+    ```
+    {
+        "id": reviewTime,
+        "usn": usn,
+        "ease": buttonPressed,
+        "ivl": newInterval,
+        "lastIvl": previousInterval,
+        "factor": newFactor,
+        "time": reviewDuration,
+        "type": reviewType,
+    }
+    ```
+    The reason why these key values are used instead of the more descriptive counterparts
+    is because these are the exact key values used in Anki's database.
 
     *Sample request*:
     ```json
@@ -2788,10 +2801,26 @@ corresponding to when the API was available for use.
     {
         "result": {
             "1653613948202": [
-                [1654102387663, 1653613948202, 1780, 3,   8,  3, 2500, 25796, 1],
-                [1654798974478, 1653613948202, 1861, 3,  20,  8, 2500, 18134, 1],
-                [1656556319328, 1653613948202, 2075, 3,  53, 20, 2500, 20530, 1],
-                [1661107990069, 1653613948202, 2478, 3, 131, 53, 2500, 24247, 1]
+                {
+                    "id": 1653772912146,
+                    "usn": 1750,
+                    "ease": 1,
+                    "ivl": -20,
+                    "lastIvl": -20,
+                    "factor": 0,
+                    "time": 38192,
+                    "type": 0
+                },
+                {
+                    "id": 1653772965429,
+                    "usn": 1750,
+                    "ease": 3,
+                    "ivl": -45,
+                    "lastIvl": -20,
+                    "factor": 0,
+                    "time": 15337,
+                    "type": 0
+                }
             ]
         },
         "error": null

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1374,6 +1374,13 @@ class AnkiConnect:
 
 
     @util.api()
+    def getReviewsOfCard(self, card):
+        return self.database().all(
+            'select id, cid, usn, ease, ivl, lastIvl, factor, time, type from revlog where cid = ?', card
+        )
+
+
+    @util.api()
     def reloadCollection(self):
         self.collection().reset()
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1375,13 +1375,15 @@ class AnkiConnect:
 
     @util.api()
     def getReviewsOfCards(self, cards):
-        return {
-            card: self.database().all(
-                "select id, cid, usn, ease, ivl, lastIvl, factor, time, type from revlog where cid = ?",
-                card,
-            )
-            for card in cards
-        }
+        COLUMNS = ['id', 'usn', 'ease', 'ivl', 'lastIvl', 'factor', 'time', 'type']
+        QUERY = 'select {} from revlog where cid = ?'.format(', '.join(COLUMNS))
+
+        result = {}
+        for card in cards:
+            query_result = self.database().all(QUERY, card)
+            result[card] = [dict(zip(COLUMNS, row)) for row in query_result]
+
+        return result
 
 
 

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1374,10 +1374,15 @@ class AnkiConnect:
 
 
     @util.api()
-    def getReviewsOfCard(self, card):
-        return self.database().all(
-            'select id, cid, usn, ease, ivl, lastIvl, factor, time, type from revlog where cid = ?', card
-        )
+    def getReviewsOfCards(self, cards):
+        return {
+            card: self.database().all(
+                "select id, cid, usn, ease, ivl, lastIvl, factor, time, type from revlog where cid = ?",
+                card,
+            )
+            for card in cards
+        }
+
 
 
     @util.api()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -29,3 +29,5 @@ class TestReviews:
 
         assert len(ac.cardReviews(deck="test_deck", startID=0)) == 2
         assert ac.getLatestReviewID(deck="test_deck") == 789
+        assert ac.getReviewsOfCard(card=setup.card_ids[0]) == \
+                [[456, setup.card_ids[0], -1, 3, 4, -60, 2500, 6157, 0]]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -30,4 +30,17 @@ class TestReviews:
         assert len(ac.cardReviews(deck="test_deck", startID=0)) == 2
         assert ac.getLatestReviewID(deck="test_deck") == 789
         assert ac.getReviewsOfCards(cards=[setup.card_ids[0]]) == \
-                {setup.card_ids[0]: [[456, setup.card_ids[0], -1, 3, 4, -60, 2500, 6157, 0]]}
+                {
+                    setup.card_ids[0]: [
+                        {
+                            "id": 456,
+                            "usn": -1,
+                            "ease": 3,
+                            "ivl": 4,
+                            "lastIvl": -60,
+                            "factor": 2500,
+                            "time": 6157,
+                            "type": 0,
+                        }
+                    ]
+                }

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -29,5 +29,5 @@ class TestReviews:
 
         assert len(ac.cardReviews(deck="test_deck", startID=0)) == 2
         assert ac.getLatestReviewID(deck="test_deck") == 789
-        assert ac.getReviewsOfCard(card=setup.card_ids[0]) == \
-                [[456, setup.card_ids[0], -1, 3, 4, -60, 2500, 6157, 0]]
+        assert ac.getReviewsOfCards(cards=[setup.card_ids[0]]) == \
+                {setup.card_ids[0]: [[456, setup.card_ids[0], -1, 3, 4, -60, 2500, 6157, 0]]}


### PR DESCRIPTION
This introduces an API action to get review data of the specified cards, compared to `cardReviews` which returns all the reviews after a given time.

## Use case
Although I'm not completely sure what other practical applications this can have, for me in particular, I'm interested in getting the earliest review time of a card to sort by for a small application in my Anki template. I figured that instead of making a specific API call to get the earliest / latest review time of a card, a more general API action like this should suffice.

## Additional Notes
Again with naming, given that there is a `cardReviews` call that already exists, I'm hoping this name is good. If you have any suggestions for potentially better names that is sufficiently different from `cardReviews`, please let me know!

Thanks!