### PR TITLE
Added modelFieldDescriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1829,6 +1829,29 @@ corresponding to when the API was available for use.
     }
     ```
 
+*   **modelFieldDescriptions**
+
+    Gets the complete list of field descriptions (the text seen in the gui editor when a field is empty) for the provided model name.
+
+    *Sample request*:
+    ```json
+    {
+        "action": "modelFieldDescriptions",
+        "version": 6,
+        "params": {
+            "modelName": "Basic"
+        }
+    }
+    ```
+
+    *Sample result*:
+    ```json
+    {
+        "result": ["", ""],
+        "error": null
+    }
+    ```
+
 *   **modelFieldsOnTemplates**
 
     Returns an object indicating the fields on the question and answer side of each card template for the given model

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1070,6 +1070,15 @@ class AnkiConnect:
 
 
     @util.api()
+    def modelFieldDescriptions(self, modelName):
+        model = self.collection().models.byName(modelName)
+        if model is None:
+            raise Exception('model was not found: {}'.format(modelName))
+        else:
+            return [field['description'] for field in model['flds']]
+
+
+    @util.api()
     def modelFieldsOnTemplates(self, modelName):
         model = self.collection().models.byName(modelName)
         if model is None:

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1075,7 +1075,12 @@ class AnkiConnect:
         if model is None:
             raise Exception('model was not found: {}'.format(modelName))
         else:
-            return [field['description'] for field in model['flds']]
+            try:
+                return [field['description'] for field in model['flds']]
+            except KeyError:
+                # older versions of Anki don't have field descriptions
+                return ['' for field in model['flds']]
+
 
 
     @util.api()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,11 @@ def test_modelFieldNames(setup):
     assert result == ["field1", "field2"]
 
 
+def test_modelFieldDescriptions(setup):
+    result = ac.modelFieldDescriptions(modelName="test_model")
+    assert result == ["", ""]
+
+
 def test_modelFieldsOnTemplates(setup):
     result = ac.modelFieldsOnTemplates(modelName="test_model")
     assert result == {


### PR DESCRIPTION
Similar to modelFieldNames, returns a list of note field decriptions (the text seen in the gui editor when the field is empty).

Closes #362 (in favor of a new issue targetting the creation of field descriptions via anki-connect).