### PR TITLE
Updated documentation on multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,8 +1670,8 @@ corresponding to when the API was available for use.
             "actions": [
                 {"action": "deckNames"},
                 {
-                    "action": "browse",
-                    "params": {"query": "deck:current"}
+                    "action": "invalidAction",
+                    "params": {"useless": "param"}
                 }
             ]
         }
@@ -1682,8 +1682,8 @@ corresponding to when the API was available for use.
     ```json
     {
         "result": [
-            {"result": "Default", "error": null},
-            {"result": [1494723142483, 1494703460437, 1494703479525], "error": null}
+            ["Default"],
+            {"result": null, "error": "unsupported action"}
         ],
         "error": null
     }

--- a/README.md
+++ b/README.md
@@ -1668,10 +1668,21 @@ corresponding to when the API was available for use.
         "version": 6,
         "params": {
             "actions": [
-                {"action": "deckNames"},
+                {
+                    "action": "deckNames"
+                },
+                {
+                    "action": "deckNames",
+                    "version": 6
+                },
                 {
                     "action": "invalidAction",
                     "params": {"useless": "param"}
+                },
+                {
+                    "action": "invalidAction",
+                    "params": {"useless": "param"},
+                    "version": 6
                 }
             ]
         }
@@ -1683,6 +1694,8 @@ corresponding to when the API was available for use.
     {
         "result": [
             ["Default"],
+            {"result": ["Default"], "error": null},
+            {"result": null, "error": "unsupported action"},
             {"result": null, "error": "unsupported action"}
         ],
         "error": null


### PR DESCRIPTION
The documentation for the `multi` action seems to be incorrect, so I updated it with the results that I got from the example code below.

In particular, on successful calls, multi does not return entries in format `{"result": ..., "error": ...}`

<details><summary>Example python code to generate the result</summary>

```python
import json
import urllib.request

def request(action, **params):
    return {'action': action, 'params': params, 'version': 6}

def invoke(action, **params):
    requestJson = json.dumps(request(action, **params)).encode('utf-8')
    response = json.load(urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson)))
    print(json.dumps(response))
    if len(response) != 2:
        raise Exception('response has an unexpected number of fields')
    if 'error' not in response:
        raise Exception('response is missing required error field')
    if 'result' not in response:
        raise Exception('response is missing required result field')
    if response['error'] is not None:
        raise Exception(response['error'])
    return response['result']

invoke("multi", actions=[
    {"action": "deckNames"},
    {"action": "invalidAction", "params": {"useless": "param"}}
])
```

</details>