### PR TITLE
fix ci by installing tox v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,15 +57,15 @@ jobs:
           sudo apt-get install -y pyqt5-dev-tools xvfb jq
 
       - name: Setup Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       - name: Install tox
-        run: pip install tox
+        run: pip install 'tox==3.28.0'
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run tests
         run: tox -vvve ${{ matrix.environment }} -- --forked --verbose

--- a/tox-install-command
+++ b/tox-install-command
@@ -13,7 +13,7 @@ upload_time=$(curl https://pypi.org/pypi/anki/json \
             | jq --arg v "$version" -r '.releases[$v][0].upload_time_iso_8601')
 cutoff_time=$(date --utc -d "$upload_time +1 hour" '+%Y-%m-%dT%H:%M:%S')
 
-coproc SERVER { "$toxworkdir"/.tox/bin/python -um pypi_timemachine "$cutoff_time"; }
+coproc SERVER { "$toxworkdir"/bin/python -um pypi_timemachine "$cutoff_time"; }
 index_url=$(print_first_group '(http\S+)' <&"${SERVER[0]}")
 
 python -m pip install --index-url "$index_url" "anki==$version" "$AQT==$version"


### PR DESCRIPTION
This PR fixes the broken CI by installing `tox` v3 in GitHub Actions. `tox` v4 is released at [Dec 8, 2022](https://pypi.org/project/tox/#history). 





Also fixed the warning below by updating some actions to latest version:

<img width="1126" alt="image" src="https://user-images.githubusercontent.com/24715727/208614128-d8eb98de-d8a8-4afb-a5eb-109d396336f2.png">

