### PR TITLE
Add getNoteTags, updateNoteTags and updateNote

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -793,6 +793,30 @@ class AnkiConnect:
 
         self.collection().autosave()
         self.stopEditing()
+    
+    
+    @util.api()
+    def updateNote(self, note):
+        self.updateNoteFields(note)
+        self.updateNoteTags(note['id'], note['tags'])
+
+
+    @util.api()
+    def updateNoteTags(self, nid, tags):
+        if type(tags) == str:
+            tags = [tags]
+        if type(tags) != list or not all([type(t) == str for t in tags]):
+            raise Exception('Must provide tags as list of strings')
+
+        for old_tag in self.getNoteTags(nid):
+            self.removeTags([nid], old_tag)
+        for new_tag in tags:
+            self.addTags([nid], new_tag)
+
+
+    @util.api()
+    def getNoteTags(self, nid):
+        return self.getNote(nid).tags
 
 
     @util.api()


### PR DESCRIPTION
Before writing README docs, are these ok? This updateNoteTags implementation is quite wasteful, but doing it like replaceTags kept not deleting tags.

getNoteTags returns [str ...] of tags for a given note (nid: int)

updateNoteTags removes the existing tags and sets new tags

updateNote combines the old updateNoteFields and the new updateNoteTags

I'd love to have these included, as implementing these client side requires a bunch of API calls. Will redo commit msg when adding docs.