### PR TITLE
Added Anki 2.1.54 - 2.1.56 to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,12 @@ jobs:
           - name: Anki 2.1.55 (Qt6)
             python: 3.9
             environment: py39-anki2.1.55-qt6
+          - name: Anki 2.1.56 (Qt5)
+            python: 3.9
+            environment: py39-anki2.1.56-qt5
+          - name: Anki 2.1.56 (Qt6)
+            python: 3.9
+            environment: py39-anki2.1.56-qt6
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,18 @@ jobs:
           - name: Anki 2.1.53 (Qt6)
             python: 3.9
             environment: py39-anki2.1.53-qt6
+          - name: Anki 2.1.54 (Qt5)
+            python: 3.9
+            environment: py39-anki2.1.54-qt5
+          - name: Anki 2.1.54 (Qt6)
+            python: 3.9
+            environment: py39-anki2.1.54-qt6
+          - name: Anki 2.1.55 (Qt5)
+            python: 3.9
+            environment: py39-anki2.1.55-qt5
+          - name: Anki 2.1.55 (Qt6)
+            python: 3.9
+            environment: py39-anki2.1.55-qt6
       fail-fast: false
 
     steps:

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -350,17 +350,22 @@ class AnkiConnect:
         # Not a duplicate
         return 0
 
+    def raiseNotfoundError(self, errorMsg):
+        if anki_version < (2, 1, 55):
+            raise NotFoundError(errorMsg)
+        raise NotFoundError(errorMsg, None, None, None)
+
     def getCard(self, card_id: int) -> Card:
         try:
             return self.collection().getCard(card_id)
         except NotFoundError:
-            raise NotFoundError('Card was not found: {}'.format(card_id))
+            self.raiseNotfoundError('Card was not found: {}'.format(card_id))
 
     def getNote(self, note_id: int) -> Note:
         try:
             return self.collection().getNote(note_id)
         except NotFoundError:
-            raise NotFoundError('Note was not found: {}'.format(note_id))
+            self.raiseNotfoundError('Note was not found: {}'.format(note_id))
 
     def deckStatsToJson(self, due_tree):
         deckStats = {'deck_id': due_tree.deck_id,

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -350,7 +350,7 @@ class AnkiConnect:
         # Not a duplicate
         return 0
 
-    def raiseNotfoundError(self, errorMsg):
+    def raiseNotFoundError(self, errorMsg):
         if anki_version < (2, 1, 55):
             raise NotFoundError(errorMsg)
         raise NotFoundError(errorMsg, None, None, None)
@@ -359,13 +359,13 @@ class AnkiConnect:
         try:
             return self.collection().getCard(card_id)
         except NotFoundError:
-            self.raiseNotfoundError('Card was not found: {}'.format(card_id))
+            self.raiseNotFoundError('Card was not found: {}'.format(card_id))
 
     def getNote(self, note_id: int) -> Note:
         try:
             return self.collection().getNote(note_id)
         except NotFoundError:
-            self.raiseNotfoundError('Note was not found: {}'.format(note_id))
+            self.raiseNotFoundError('Note was not found: {}'.format(note_id))
 
     def deckStatsToJson(self, due_tree):
         deckStats = {'deck_id': due_tree.deck_id,

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ requires =
     pypi-timemachine
 envlist =
     py38-anki2.1.{45,46,47,48,49}
-    py39-anki2.1.{50,51,52,53}-qt{5,6}
+    py39-anki2.1.{50,51,52,53,54,55}-qt{5,6}
 
 [testenv:.tox]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ requires =
     pypi-timemachine
 envlist =
     py38-anki2.1.{45,46,47,48,49}
-    py39-anki2.1.{50,51,52,53,54,55}-qt{5,6}
+    py39-anki2.1.{50,51,52,53,54,55,56}-qt{5,6}
 
 [testenv:.tox]
 install_command =


### PR DESCRIPTION
2.1.55 seems to break some tests, notably ones that raise `NotFoundError`. This was fixed by adding a few `None` arguments, similarly to how it's done [in Anki itself.](https://github.com/ankitects/anki/blob/22f54c2c01562b4d5563a920b51f0aebb6a6e125/qt/aqt/browser/table/state.py#L197)