### PR TITLE
Return deckName in notesInfo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3308,6 +3308,7 @@ corresponding to when the API was available for use.
             {
                 "noteId":1502298033753,
                 "modelName": "Basic",
+                "deckName": "Default",
                 "tags":["tag","another_tag"],
                 "fields": {
                     "Front": {"value": "front content", "order": 0},

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1502,6 +1502,7 @@ class AnkiConnect:
                     'tags' : note.tags,
                     'fields': fields,
                     'modelName': model['name'],
+                    'deckName': self.decks().get(model['did'])['name'],
                     'cards': self.collection().db.list('select id from cards where nid = ? order by ord', note.id)
                 })
             except NotFoundError:

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -65,6 +65,8 @@ def test_notesInfo(setup):
     assert len(result) == 1
     assert result[0]["noteId"] == setup.note1_id
     assert result[0]["tags"] == ["tag1"]
+    assert result[0]["modelName"] == "test_model"
+    assert result[0]["deckName"] == "test_deck"
     assert result[0]["fields"]["field1"]["value"] == "note1 field1"
 
 


### PR DESCRIPTION
If I'm not wrong there was previously no way to get the name (or id) of the deck the note belongs to.

I've tested my changes with python3.10. Is there anything else I have (or can) do?