### PR TITLE
Update described result from createModel api

### DIFF
--- a/README.md
+++ b/README.md
@@ -2413,7 +2413,7 @@ corresponding to when the API was available for use.
             "tags":[
 
             ],
-            "id":"1551462107104",
+            "id":1551462107104,
             "req":[
                 [
                     0,


### PR DESCRIPTION
I have been working on a wrapper for anki-connect in go. It serializes the requests into a typed Go struct. To create these structs I have been using the types present in the provided examples of api results. It looks like the format of the id for createModel result has either changed, or was entered wrong. See https://github.com/dlangevi/ankiconnect/commit/f3e9a5b709b9c3fceff4b312c92a3e342e8e944c for an example of what the current version of anki + anki-connect returns for this api call