### PR TITLE
add a new action: getMediaDirPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1759,6 +1759,32 @@ corresponding to when the API was available for use.
     ```
     </details>
 
+#### `getMediaDirPath`
+
+*   Gets the full path to the `collection.media` folder of the currently opened profile.
+
+    <details>
+    <summary><i>Sample request:</i></summary>
+
+    ```json
+    {
+        "action": "getMediaDirPath",
+        "version": 6
+    }
+    ```
+    </details>
+
+    <details>
+    <summary><i>Sample result:</i></summary>
+
+    ```json
+    {
+        "result": "/home/user/.local/share/Anki2/Main/collection.media",
+        "error": null
+    }
+    ```
+    </details>
+
 #### `deleteMediaFile`
 
 *   Deletes the specified file inside the media folder.

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -722,6 +722,9 @@ class AnkiConnect:
         except AttributeError:
             self.media().trash_files([filename])
 
+    @util.api()
+    def getMediaDirPath(self):
+        return os.path.abspath(self.media().dir())
 
     @util.api()
     def addNote(self, note):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,4 +1,5 @@
 import base64
+import os.path
 
 from conftest import ac
 
@@ -49,3 +50,7 @@ def test_deleteMediaFile(session_with_profile_loaded):
     ac.deleteMediaFile(filename=filename_1)
     assert ac.retrieveMediaFile(filename=filename_1) is False
     assert ac.getMediaFilesNames(pattern="_tes*.txt") == [filename_2]
+
+
+def test_getMediaDirPath(session_with_profile_loaded):
+    assert os.path.isdir(ac.getMediaDirPath())


### PR DESCRIPTION
This PR adds the `getMediaDirPath` action that returns the full path to the user's collection folder. 

Currently Mpvacious has to rely on the `storeMediaFile` action to add new audio and images to the collection, but this [proves to be problematic](https://github.com/Ajatt-Tools/mpvacious/issues/94). When called with base64-encoded data, it may fail if the file is too big, and when called with a path to a temporary file, it may fail because Anki doesn't have access to the folder where the file is stored.

With this function we would be able to send files directly to the `collection.media` folder without encoding them as base64 or using temporary files.