### PR TITLE
Updated Python example code to use 127.0.0.1 instead of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ def request(action, **params):
 
 def invoke(action, **params):
     requestJson = json.dumps(request(action, **params)).encode('utf-8')
-    response = json.load(urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson)))
+    response = json.load(urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:8765', requestJson)))
     if len(response) != 2:
         raise Exception('response has an unexpected number of fields')
     if 'error' not in response:


### PR DESCRIPTION
Apparently, `urllib.request.urlopen` takes a very long time to load when using `localhost` instead of `127.0.0.1` on Windows. This PR simply changes `localhost` to `127.0.0.1` in the sample code.

I initially thought of doing something like:
```
import platform
url = "127.0.0.1" if platform.system() == "Windows" else "localhost"
```
However, given that the Javascript example is using 127.0.0.1 already, I figured it is fine to replace `localhost` entirely.

Related issue & more reading material: #389 