### PR TITLE
Add a method to bring up Import File dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,6 +1617,35 @@ corresponding to when the API was available for use.
     ```
     </details>
 
+#### `guiImportFile`
+
+*   Invokes the *Import... (Ctrl+Shift+I)* dialog with an optional file path. Brings up the dialog for user to review the import. Supports all file types that Anki supports. Brings open file dialog if no path is provided. Forward slashes must be used in the path on Windows.
+
+    <details>
+    <summary><i>Sample request:</i></summary>
+
+    ```json
+    {
+        "action": "guiImportFile",
+        "version": 6,
+        "params": {
+            "path": "C:/Users/Desktop/cards.txt"
+        }
+    }
+    ```
+    </details>
+
+    <details>
+    <summary><i>Sample result:</i></summary>
+
+    ```json
+    {
+        "result": null,
+        "error": null
+    }
+    ```
+    </details>
+
 #### `guiExitAnki`
 
 *   Schedules a request to gracefully close Anki. This operation is asynchronous, so it will return immediately and

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -41,6 +41,7 @@ from anki.exporting import AnkiPackageExporter
 from anki.importing import AnkiPackageImporter
 from anki.notes import Note
 from anki.errors import NotFoundError
+from aqt.import_export.importing import import_file, prompt_for_file_then_import
 from aqt.qt import Qt, QTimer, QMessageBox, QCheckBox
 
 from .web import format_exception_reply, format_success_reply
@@ -1850,6 +1851,32 @@ class AnkiConnect:
             return True
 
         return False
+
+
+    @util.api()
+    def guiImportFile(self, path=None):
+        """
+        Open Import File (Ctrl+Shift+I) dialog with provided file path.
+        If no path is given, the user will be prompted to select a file.
+
+        path: string
+            import file path, note on Windows you must use forward slashes.
+        """
+
+        # Bring window to top for user to review import settings.
+        try:
+            # [Step 1/2] set always on top flag, show window (it stays on top for now)
+            self.window().setWindowFlags(self.window().windowFlags() | Qt.WindowStaysOnTopHint)  
+            self.window().show()
+        finally:
+            # [Step 2/2] clear always on top flag, show window (it doesn't stay on top anymore)
+            self.window().setWindowFlags(self.window().windowFlags() & ~Qt.WindowStaysOnTopHint) 
+            self.window().show()
+
+        if path is None:
+            prompt_for_file_then_import(self.window())
+        else:
+            import_file(self.window(), path)
 
 
     @util.api()

--- a/tests/test_graphical.py
+++ b/tests/test_graphical.py
@@ -28,6 +28,10 @@ def test_guiDeckOverview(setup):
     assert ac.guiDeckOverview(name="test_deck") is True
 
 
+def test_guiImportFile(setup):
+    ac.guiImportFile()
+
+
 class TestAddCards:
     note = {
         "deckName": "test_deck",


### PR DESCRIPTION
Hi, 

Thanks for this great plugin! Hope you can have a look at this PR when you have a moment.

Currently AnkiConnect only supports importing of `apkg` file. This PR adds the support to import all file types by adding a GUI action to bring up the "Import... (Ctrl+Shift+I)" dialog.

If a path is provided, it brings up an "Import File" window with provided file. If no path is provided, it brings up select file window followed by "Import File" window. 

To avoid being overlooked by the user, Anki window is brought to front in this action.

See below screenshot for the "Import File" window brought up by the following command in PowerShell. 

```
(Invoke-RestMethod -Uri http://localhost:8765 -Method Post -Body '{"action": "guiImportFile", "version": 6, "params": {"path": "C:/Users/Downloads/anki-import.txt"}}')
```

![image](https://github.com/FooSoft/anki-connect/assets/8330956/14462ffc-eafd-49ce-9071-e652025058e7)

Thanks a lot.

Please kindly let me know if any comments. 