### PR TITLE
Fix #392 with version check for Anki and Qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1619,7 +1619,7 @@ corresponding to when the API was available for use.
 
 #### `guiImportFile`
 
-*   Invokes the *Import... (Ctrl+Shift+I)* dialog with an optional file path. Brings up the dialog for user to review the import. Supports all file types that Anki supports. Brings open file dialog if no path is provided. Forward slashes must be used in the path on Windows.
+*   Invokes the *Import... (Ctrl+Shift+I)* dialog with an optional file path. Brings up the dialog for user to review the import. Supports all file types that Anki supports. Brings open file dialog if no path is provided. Forward slashes must be used in the path on Windows. Only supported for Anki 2.1.52+.
 
     <details>
     <summary><i>Sample request:</i></summary>

--- a/tests/test_graphical.py
+++ b/tests/test_graphical.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest import mock
 
 from conftest import ac, anki_version, wait_until, \
         close_all_dialogs_and_wait_for_them_to_run_closing_callbacks, \
@@ -30,7 +31,9 @@ def test_guiDeckOverview(setup):
 
 def test_guiImportFile(setup):
     if anki_version >= (2, 1, 52):
-        ac.guiImportFile()
+        with mock.patch('aqt.import_export.importing.prompt_for_file_then_import') as mock_prompt_for_file_then_import:
+            mock_prompt_for_file_then_import.return_value = True
+            ac.guiImportFile()
 
 
 class TestAddCards:

--- a/tests/test_graphical.py
+++ b/tests/test_graphical.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import ac, wait_until, \
+from conftest import ac, anki_version, wait_until, \
         close_all_dialogs_and_wait_for_them_to_run_closing_callbacks, \
         get_dialog_instance
 
@@ -29,7 +29,8 @@ def test_guiDeckOverview(setup):
 
 
 def test_guiImportFile(setup):
-    ac.guiImportFile()
+    if anki_version >= (2, 1, 52):
+        ac.guiImportFile()
 
 
 class TestAddCards:


### PR DESCRIPTION
Hi, 

Some tests are failing due to #392 , there are two kinds of errors

1. `aqt.import_export` doesn't exist, it turns out this is only added in Anki 2.1.52. See #1743 in https://github.com/ankitects/anki/compare/2.1.51...2.1.52 
2. `Qt.WindowStaysOnTopHint` doesn't exist, it turns out it's of a different name in Qt6. 

This pull request is to handle both and update doc to make it clear `guiImportFile` is only supported >=2.1.52

Thanks!