### PR TITLE
Make it slightly clearer how to enable authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ const result = await invoke('deckNames', 6);
 console.log(`got list of decks: ${result}`);
 ```
 
+### Authentication
+
+Anki-Connect supports requiring authentication in order to make API requests.
+This support is *disabled* by default, but can be enabled by setting the `apiKey` field of Anki-Config's settings (Tools->Add-ons->AnkiConnect->Config) to a desired string.
+If you have done so, you should see the [`requestPermission`](#requestpermission) API request return `true` for `requireApiKey`.
+You then must include an additional parameter called `key` in any further API request bodies, whose value must match the configured API key.
+
 ### Hey, could you add a new action to support $FEATURE?
 
 The primary goal for Anki-Connect was to support real-time flash card creation from the


### PR DESCRIPTION
The README previously sort of covered this, but in particular it was not obvious to me that the request parameter that corresponded to enabling `apiKey` is called `key`, and not `apiKey`, which ultimately made me have to look at the source code to figure this out (even though the word `key` is mentioned elsewhere on the page, it still wasn't very easy to make the connection).

This section puts all the required information in one spot.